### PR TITLE
Pathz improvements

### DIFF
--- a/authorization/BUILD.bazel
+++ b/authorization/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "authorization_proto",
     srcs = ["authorization.proto"],
+    import_prefix = "github.com/openconfig/gnsi",
     deps = ["@com_github_openconfig_gnmi//proto/gnmi:gnmi_proto"],
 )
 

--- a/authz/BUILD.bazel
+++ b/authz/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "authz_proto",
     srcs = ["authz.proto"],
+    import_prefix = "github.com/openconfig/gnsi",
     deps = ["@com_github_openconfig_gnoi//types:types_proto"],
 )
 

--- a/cert/BUILD.bazel
+++ b/cert/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "cert_proto",
     srcs = ["cert.proto"],
+    import_prefix = "github.com/openconfig/gnsi",
     deps = [
         "@com_github_openconfig_gnoi//types:types_proto",
     ],

--- a/console/BUILD.bazel
+++ b/console/BUILD.bazel
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "console_proto",
     srcs = ["console.proto"],
+    import_prefix = "github.com/openconfig/gnsi",
     deps = ["@com_github_openconfig_gnoi//types:types_proto"],
 )
 

--- a/pathz/BUILD.bazel
+++ b/pathz/BUILD.bazel
@@ -10,8 +10,9 @@ proto_library(
     srcs = ["pathz.proto"],
     import_prefix = "github.com/openconfig/gnsi",
     deps = [
+        "//authorization:authorization_proto",
+        "@com_github_openconfig_gnmi//proto/gnmi:gnmi_proto",
         "@com_github_openconfig_gnoi//types:types_proto",
-        "@com_google_protobuf//:any_proto",
     ],
 )
 
@@ -22,6 +23,9 @@ cpp_grpc_library(
     name = "pathz_cc_proto",
     protos = [
         ":pathz_proto",
+        "//authorization:authorization_proto",
+        "@com_github_openconfig_gnmi//proto/gnmi:gnmi_proto",
+        "@com_github_openconfig_gnmi//proto/gnmi_ext:gnmi_ext_proto",
         "@com_github_openconfig_gnoi//types:types_proto",
     ],
 )
@@ -35,7 +39,8 @@ go_proto_library(
     importpath = "github.com/openconfig/gnsi/pathz",
     proto = ":pathz_proto",
     deps = [
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+        "//authorization:authorization_go_proto",
+        "@com_github_openconfig_gnmi//proto/gnmi:gnmi_go_proto",
         "@com_github_openconfig_gnoi//types:types_go_proto",
     ],
 )

--- a/pathz/BUILD.bazel
+++ b/pathz/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "pathz_proto",
     srcs = ["pathz.proto"],
+    import_prefix = "github.com/openconfig/gnsi",
     deps = [
         "@com_github_openconfig_gnoi//types:types_proto",
         "@com_google_protobuf//:any_proto",

--- a/pathz/pathz.proto
+++ b/pathz/pathz.proto
@@ -20,10 +20,11 @@ syntax = "proto3";
 
 package gnsi.pathz;
 
+import "github.com/openconfig/gnmi/proto/gnmi/gnmi.proto";
 import "github.com/openconfig/gnoi/types/types.proto";
-import "google/protobuf/any.proto";
+import "github.com/openconfig/gnsi/authorization/authorization.proto";
 
-option go_package = "github.com/openconfig/gnsi/pathz";
+option go_package = "gnsi.googlesource.com/gnsi/pathz";
 option (gnoi.types.gnoi_version) = "0.1.0";
 
 // The OpenConfig Path-based Authz Policy Management Service exported by
@@ -40,7 +41,7 @@ option (gnoi.types.gnoi_version) = "0.1.0";
 // Activation of a standby policy is not handled by this service and is done
 // using the gNMI API.
 
-service PathzManagement {
+service Pathz {
 
   // Rotate will replace an existing OpenConfig Path-based Authz Policy on
   // the target.
@@ -114,6 +115,12 @@ service PathzManagement {
   //
   rpc Install(stream InstallPathzRequest)
       returns (stream InstallPathzResponse);
+
+  // Probe allows for evaluation of the pathz policy engine response to a gNMI
+  // operation performed by a user on a single gNMI path.
+  // The response is based on the currently active policy and is evaluated
+  // without actually performing the gNMI operation.
+  rpc Probe(ProbeRequest) returns (ProbeResponse);
 }
 
 // Request messages to rotate existing OpenConfig Path-based Authz Policy on
@@ -201,10 +208,23 @@ message UploadRequest {
   uint64 created_on = 3;
 
   // The actual OpenConfig Path-based Authz Policy.
-  // It is provided as a PROTO that is defined by
-  // https://github.com/openconfig/public/release/authorization/authorization.proto.
-  google.protobuf.Any policy = 4;
+  gnsi.authorization.AuthorizationPolicy policy = 4;
 }
 
 message UploadResponse {}
 
+// ProbeRequest contains a single user name and gNMI Path being attempted.
+// Data returned to an RPC Caller should adhere to the policy.
+message ProbeRequest {
+  string user = 1;
+  gnmi.Path path = 2;
+}
+
+// ProbeResponse returns the ack/nack for a single user request
+// as evaluated against the current policy, along with the policy ID
+// and current policy version.
+message ProbeResponse {
+  gnsi.authorization.Action action = 1;
+  string id = 2;
+  string version = 3;
+}

--- a/pathz/pathz.proto
+++ b/pathz/pathz.proto
@@ -24,7 +24,7 @@ import "github.com/openconfig/gnmi/proto/gnmi/gnmi.proto";
 import "github.com/openconfig/gnoi/types/types.proto";
 import "github.com/openconfig/gnsi/authorization/authorization.proto";
 
-option go_package = "gnsi.googlesource.com/gnsi/pathz";
+option go_package = "github.com/openconfig/gnsi/pathz";
 option (gnoi.types.gnoi_version) = "0.1.0";
 
 // The OpenConfig Path-based Authz Policy Management Service exported by

--- a/ssh/BUILD.bazel
+++ b/ssh/BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "ssh_proto",
     srcs = ["ssh.proto"],
+    import_prefix = "github.com/openconfig/gnsi",
     deps = ["@com_github_openconfig_gnoi//types:types_proto"],
 )
 


### PR DESCRIPTION
    Pathz improvements
    
    * Changes name of `PathzManagement` service name to `Pathz`
    * Adds `Probe()` RPC to check if an operation is permitted for a specified user
    * The policy field now has to be of `gnsi.authorization.AuthorizationPolicy` type