### PR TITLE
Change the authorization proto and associated documentation

### DIFF
--- a/authorization/README.md
+++ b/authorization/README.md
@@ -7,10 +7,10 @@ to describe an authorization framework for controlling which gNMI paths of a
 network device users can access. The authorization policy is initially intended
 to be deployed to a device, with the ability to define:
 
-*   Policy rules - each rule defines a single authorization policy.
-*   Groups of users - as a method to logically group users in the administrative
-    domain, for instance: operators or administrators.
-*   Users - individuals referenced in rules or group definitions.
+* Policy rules - each rule defines a single authorization policy.
+* Groups of users - as a method to logically group users in the administrative
+  domain, for instance: operators or administrators.
+* Users - individuals referenced in rules or group definitions.
 
 Authentication information is not included in this Authorization configuration.
 
@@ -29,9 +29,9 @@ Action (PERMIT/DENY), policy version, and rule identifier.
 A Best, or most specific, match is that which has the longest match to the
 requested path and prefers:
 
-*   a specific user over a group in the matching policy.
-*   a defined KEY over a wildcard element in a keyed path.
-*   a mode which matches that of the request (READ/WRITE).
+* a specific user over a group in the matching policy.
+* a defined KEY over a wildcard element in a keyed path.
+* a mode which matches that of the request (READ/WRITE).
 
 Authorization rules must be defined such that a single best match is possible.
 If the result of policy evaluation is more than one match, an error must be
@@ -39,9 +39,9 @@ raised.
 
 Match rules permit a match against:
 
-*   User or Group (not both)
-*   an gNMI path
-*   an access mode (READ / WRITE)
+* User or Group (not both)
+* an gNMI path
+* an access mode (READ / WRITE)
 
 An implicit deny is assumed, if there is no matching rule in the policy.
 

--- a/authorization/authorization.proto
+++ b/authorization/authorization.proto
@@ -55,13 +55,6 @@ message Group {
   repeated User users = 2;
 }
 
-// LogLevel is set for all RPCs (via default_log_level, or per-RPC specifically.
-enum LogLevel {
-  LOG_NONE = 0;   // Don't pollute the logs with high volume RPCs.
-  LOG_BRIEF = 1;  // RPC name and calling Principal name.
-  LOG_FULL = 2;   // RPC, Principal, Request, and Response.
-}
-
 // Action is the defined action for an AuthorizationPolicy.
 enum Action {
   ACTION_UNKNOWN = 0;
@@ -69,36 +62,33 @@ enum Action {
   ACTION_PERMIT = 2;
 }
 
-// Method is:
-//   GET: Ability to view/read data.
-//   SUBSCRIBE: Ability to subscribe for updates to data.
-//   SET: Ability to mutate data, with a set request.
-enum Level {
-  LEVEL_UNDEFINED = 0;
-  LEVEL_GET = 1;
-  LEVEL_SUBSCRIBE = 2;
-  LEVEL_SET = 3;
+// Mode is:
+//   READ: Ability to read/subscribe to data from the model.
+//   WRITE: Ability to mutate/write updates to data in the model.
+enum Mode {
+  MODE_UNDEFINED = 0;
+  MODE_READ = 1;
+  MODE_WRITE = 2;
 }
 
 message AuthorizationRule {
   // Policy Identifier, a unique string per policy/rule, eg: uuid.
   string id = 1;
-  LogLevel log_level = 2;
 
   oneof principal {
-    string user = 3;
-    string group = 4;
+    string user = 2;
+    string group = 3;
   }
 
   // Path is the request path, longest prefix (by path elements from left
   // to right).
-  gnmi.Path path = 5;
+  gnmi.Path path = 4;
 
   // Permit or deny the user/group access to the path specified.
-  Action action = 6;
+  Action action = 5;
 
-  // Permit Read, Write, or Read and Write access to the path specified.
-  repeated Level level = 7;
+  // Permit Read or Write access to the path specified.
+  Mode mode = 6;
 }
 
 // AuthorizationPolicy includes rules and user/group information.
@@ -107,35 +97,6 @@ message AuthorizationRule {
 //   version - string - unique among the implementation's policies deployed.
 message AuthorizationPolicy {
   repeated AuthorizationRule rules = 1;
-  // Default RPC log level, used only if an RPC has no defined logging level.
-  LogLevel default_log_level = 2;
   // Groups of usernames collected for simplicity of policy expression.
-  repeated Group groups = 3;
-}
-
-// AuthorizationRequest contains a single user name and
-// gnmi Path being attempted. Data returned to an RPC Caller should
-// adhere to the policy.
-message AuthorizationRequest {
-  string user = 1;
-  gnmi.Path path = 2;
-}
-
-// AuthorizationReply returns the ack/nack for a single user request
-// as evaluated against the current policy, along with the policy id
-// and current policy version.
-message AuthorizationReply {
-  Action action = 1;
-  string id = 2;
-  string version = 3;
-}
-
-// VersionRequest requires no content, this is a simple status request.
-message VersionRequest {}
-
-// VersionReply returns only the version string and timestamp
-// of policy creation.
-message VersionReply {
-  string version = 1;
-  int64 created_on = 2;
+  repeated Group groups = 2;
 }

--- a/authorization/authorization.proto
+++ b/authorization/authorization.proto
@@ -23,7 +23,7 @@
 // Paths may be referenced in whole or in complete parts, ie:
 //   /interfaces/interface[name=Ethernet1/2/3]/state/counters
 //   /interfaces/interface[name=*]/state/oper-status
-//   /network-instances/network-instance/tables/table[protocol=BGP][address-family=*]
+//   /network-instances/network-instance/tables/table[proto=BGP][family=*]
 //
 // Paths are gnmi.Path protobufs.
 //
@@ -57,7 +57,7 @@ message Group {
 
 // Action is the defined action for an AuthorizationPolicy.
 enum Action {
-  ACTION_UNKNOWN = 0;
+  ACTION_UNSPECIFIED = 0;
   ACTION_DENY = 1;
   ACTION_PERMIT = 2;
 }
@@ -66,7 +66,7 @@ enum Action {
 //   READ: Ability to read/subscribe to data from the model.
 //   WRITE: Ability to mutate/write updates to data in the model.
 enum Mode {
-  MODE_UNDEFINED = 0;
+  MODE_UNSPECIFIED = 0;
   MODE_READ = 1;
   MODE_WRITE = 2;
 }

--- a/authorization/authorization.proto
+++ b/authorization/authorization.proto
@@ -69,15 +69,15 @@ enum Action {
   ACTION_PERMIT = 2;
 }
 
-// Level is:
-//   READ: Ability to view/read data.
+// Method is:
+//   GET: Ability to view/read data.
 //   SUBSCRIBE: Ability to subscribe for updates to data.
-//   WRITE: Ability to mutate data.
+//   SET: Ability to mutate data, with a set request.
 enum Level {
   LEVEL_UNDEFINED = 0;
-  LEVEL_READ = 1;
+  LEVEL_GET = 1;
   LEVEL_SUBSCRIBE = 2;
-  LEVEL_WRITE = 3;
+  LEVEL_SET = 3;
 }
 
 message AuthorizationRule {

--- a/authorization/index.md
+++ b/authorization/index.md
@@ -1,0 +1,90 @@
+# gNSI Authorization Protobuf Definition.
+**Contributors**: hines@google.com, morrowc@google.com, tmadejski@google.com
+**Last Updated**: 2022-07-12
+
+## Background
+
+The authorization proto definition provides a clear method to define
+and implement policy authorizing user or group access to the management
+systems and interfaces of a network deployment. The ability to permit
+or deny access to these systems and interfaces is intended to help
+operate a network in a more safe and secure manner.
+
+## Motivation
+
+Authorization services for network systems can, at times, be operated
+as remote services. One example of this is a TACACS+ service, there are
+inherent challenges with operating a network and relying upon a remote
+service for critical functions performed on network systems. A solution
+to provide on-device Authorization with the fidelity of remote services
+should be provided.
+
+## Architecture
+
+There is no requirement for the Authorization policy to be evaluated:
+on the local network system, in a microservice operated on the network
+system, or in every gNMI service individually on the network system.
+It is expected that gNMI services enabled on a network system respect
+the AuthorizationPolicy installed, however.
+
+#### Pathz.Install()
+
+Pathz.Install() will permit installation, and verification of function,
+of an AuthorizationPolicy. The normal use-case would be to:
+
+* send an AuthorizationPolicy{} to a network system as an
+InstallPathzRequest{}
+* verify access/authorization has changed to the desired state
+through existing gNMI methods, or with pathz.Probe() requests.
+* send a FinalizeRequest{} to finish the installation process.
+
+#### Pathz.Rotate()
+
+Pathz.Rotate() will permit rotation, and verification of function,
+of an AuthorizationPolicy. The normal use-case would be to:
+
+* send an AuthorizationPolicy{} to a network system as a
+RotatePathzRequest{}
+* verify access/authorization has changed to the desired state
+through existing gNMI methods, or with pathz.Probe() requests.
+* send a FinalizeRequest{} to finish the installation process.
+
+#### Pathz.Probe()
+
+Pathz.Probe() provides a method to test the AuthorizationPolicy
+with a ProbeRequest{} which includes a user and gNMI path. This
+enables network operations and management systems to verify that
+the access expected is either permitted or denied in accordance
+with the expected to be deployed AuthroizationPolicy.
+
+## User Experiences
+
+#### An AuthorizationPolicy is to be installed.
+
+##### Expected Action
+
+Create, and test, a new AuthorizationPolicy{}.
+
+Send that policy to the target network system with a call to pathz.Install()
+
+Verify that the policy newly deployed performs according to the documented
+intent, by sending pathz.Probe() requests to the network system.
+
+Send a Finalize{} message to the pathz.Install() rpc.
+
+#### An AuthorizationPolicy is to be rotated or updated.
+
+##### Expected Action
+
+Create, and test, a new AuthorizationPolicy{}.
+
+Send that policy to the target network system with a call to pathz.Rotate()
+
+Verify that the policy newly rotated performs according to the documented
+intent, by sending pathz.Probe() requests to the network system.
+
+Send a Finalize{} message to the pathz.Rotate() rpc.
+
+## Open Questions/Considerations
+
+None to date.

--- a/authorization/index.md
+++ b/authorization/index.md
@@ -36,7 +36,7 @@ to the Finalize message being received at the server, the candidate
 AuthorizationPolicy is discarded and the existing policy again becomes
 active.
 
-#### Pathz.Install
+### Pathz.Install
 
 Pathz.Install will permit installation, and verification of function,
 of an AuthorizationPolicy. The normal use-case would be to:
@@ -47,7 +47,7 @@ InstallPathzRequest
 through existing gNMI methods, or with pathz.Probe requests.
 * send a FinalizeRequest to finish the installation process.
 
-#### Pathz.Rotate
+### Pathz.Rotate
 
 Pathz.Rotate will permit rotation, and verification of function,
 of an AuthorizationPolicy. The normal use-case would be to:
@@ -58,7 +58,7 @@ RotatePathzRequest
 through existing gNMI methods, or with pathz.Probe requests.
 * send a FinalizeRequest to finish the installation process.
 
-#### Pathz.Probe
+### Pathz.Probe
 
 Pathz.Probe provides a method to test the AuthorizationPolicy
 with a path.ProbeRequest which includes a user and gNMI path. This

--- a/authorization/index.md
+++ b/authorization/index.md
@@ -27,6 +27,15 @@ system, or in every gNMI service individually on the network system.
 It is expected that gNMI services enabled on a network system respect
 the AuthorizationPolicy installed, however.
 
+The pathz.Install and pathz.Rotate rpcs are bi-directional streaming
+rpcs, it's possible to send more than one policy change through an
+open stream checkpointing the policy with pathz.Finalize messages or
+replacing the candidate AuthorizationPolicy to verify functionality
+changes prior to the Finalize message. If the stream is closed prior
+to the Finalize message being received at the server, the candidate
+AuthorizationPolicy is discarded and the existing policy again becomes
+active.
+
 #### Pathz.Install()
 
 Pathz.Install() will permit installation, and verification of function,
@@ -59,31 +68,43 @@ with the expected to be deployed AuthroizationPolicy.
 
 ## User Experiences
 
-#### An AuthorizationPolicy is to be installed.
+### An AuthorizationPolicy is to be installed.
 
-##### Expected Action
+#### Expected Action
 
 Create, and test, a new AuthorizationPolicy{}.
 
-Send that policy to the target network system with a call to pathz.Install()
+Send that policy to the target network system with a
+pathz.InstallAuthzRequest to the pathz.Install rpc. The
+InstallAuthzRequest's install_request will be a pathz.UploadRequest.
 
 Verify that the policy newly deployed performs according to the documented
-intent, by sending pathz.Probe() requests to the network system.
+intent, by sending pathz.Probe requests to the network system.
 
-Send a Finalize{} message to the pathz.Install() rpc.
+Send a pathz.Finalize message to the pathz.Install() rpc to close
+out the action.
 
-#### An AuthorizationPolicy is to be rotated or updated.
+If the stream is disconnected prior to the Finalize message being
+sent, the proposed configuration is rolled back automatically.
 
-##### Expected Action
+### An AuthorizationPolicy is to be rotated or updated.
+
+#### Expected Action
 
 Create, and test, a new AuthorizationPolicy{}.
 
-Send that policy to the target network system with a call to pathz.Rotate()
+Send that policy to the target network system with a
+pathz.RotateAuthzRequest to pathz.Rotate rpc. The
+RotateAuthzRequest's rotate_request will be a pathz.UploadRequest.
 
 Verify that the policy newly rotated performs according to the documented
-intent, by sending pathz.Probe() requests to the network system.
+intent, by sending pathz.Probe requests to the network system.
 
-Send a Finalize{} message to the pathz.Rotate() rpc.
+Send a Finalize message to the pathz.Rotate rpc to close
+out the action.
+
+If the stream is disconnected prior to the Finalize message being
+sent, the proposed configuration is rolled back automatically.
 
 ## Open Questions/Considerations
 

--- a/authorization/index.md
+++ b/authorization/index.md
@@ -1,4 +1,4 @@
-# gNSI Authorization Protobuf Definition.
+# gNSI Authorization Protobuf Definition
 **Contributors**: hines@google.com, morrowc@google.com, tmadejski@google.com
 **Last Updated**: 2022-07-12
 
@@ -36,43 +36,41 @@ to the Finalize message being received at the server, the candidate
 AuthorizationPolicy is discarded and the existing policy again becomes
 active.
 
-#### Pathz.Install()
+#### Pathz.Install
 
-Pathz.Install() will permit installation, and verification of function,
+Pathz.Install will permit installation, and verification of function,
 of an AuthorizationPolicy. The normal use-case would be to:
 
-* send an AuthorizationPolicy{} to a network system as an
-InstallPathzRequest{}
+* send an AuthorizationPolicy to a network system as an
+InstallPathzRequest
 * verify access/authorization has changed to the desired state
-through existing gNMI methods, or with pathz.Probe() requests.
-* send a FinalizeRequest{} to finish the installation process.
+through existing gNMI methods, or with pathz.Probe requests.
+* send a FinalizeRequest to finish the installation process.
 
-#### Pathz.Rotate()
+#### Pathz.Rotate
 
-Pathz.Rotate() will permit rotation, and verification of function,
+Pathz.Rotate will permit rotation, and verification of function,
 of an AuthorizationPolicy. The normal use-case would be to:
 
-* send an AuthorizationPolicy{} to a network system as a
-RotatePathzRequest{}
+* send an AuthorizationPolicy to a network system as a
+RotatePathzRequest
 * verify access/authorization has changed to the desired state
-through existing gNMI methods, or with pathz.Probe() requests.
-* send a FinalizeRequest{} to finish the installation process.
+through existing gNMI methods, or with pathz.Probe requests.
+* send a FinalizeRequest to finish the installation process.
 
-#### Pathz.Probe()
+#### Pathz.Probe
 
-Pathz.Probe() provides a method to test the AuthorizationPolicy
-with a ProbeRequest{} which includes a user and gNMI path. This
+Pathz.Probe provides a method to test the AuthorizationPolicy
+with a path.ProbeRequest which includes a user and gNMI path. This
 enables network operations and management systems to verify that
 the access expected is either permitted or denied in accordance
 with the expected to be deployed AuthroizationPolicy.
 
 ## User Experiences
 
-### An AuthorizationPolicy is to be installed.
+### An AuthorizationPolicy is to be installed
 
-#### Expected Action
-
-Create, and test, a new AuthorizationPolicy{}.
+Create, and test, a new AuthorizationPolicy.
 
 Send that policy to the target network system with a
 pathz.InstallAuthzRequest to the pathz.Install rpc. The
@@ -87,11 +85,9 @@ out the action.
 If the stream is disconnected prior to the Finalize message being
 sent, the proposed configuration is rolled back automatically.
 
-### An AuthorizationPolicy is to be rotated or updated.
+### An AuthorizationPolicy is to be rotated or updated
 
-#### Expected Action
-
-Create, and test, a new AuthorizationPolicy{}.
+Create, and test, a new AuthorizationPolicy.
 
 Send that policy to the target network system with a
 pathz.RotateAuthzRequest to pathz.Rotate rpc. The


### PR DESCRIPTION
Offline discussions lead to some cleanup and conformal coating of the proto/documentation.
Effectively attempt to get the language/usage in line with gNMI normsl