### PR TITLE
Removing unbounded collection of pathz policies. Now active + sandbox pathz policies only.

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,0 +1,59 @@
+---
+###########################################
+# These are the rules used for            #
+# linting all the yaml files in the stack #
+# NOTE:                                   #
+# You can disable line with:              #
+# # yamllint disable-line                 #
+###########################################
+rules:
+  braces:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 5
+  brackets:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 5
+  colons:
+    level: warning
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    level: warning
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start:
+    level: warning
+    present: true
+  empty-lines:
+    level: warning
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    level: warning
+    max-spaces-after: 1
+  indentation:
+    level: warning
+    spaces: consistent
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length:
+    level: warning
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,6 +35,7 @@ jobs:
         uses: github/super-linter/slim@v4
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_HTML: false
           VALIDATE_JSCPD: false
           VALIDATE_GO: false
           IGNORE_GENERATED_FILES: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
+# gNSI - gRPC Network Security Interface
+
 [![License: Apache](https://img.shields.io/badge/license-Apache%202-blue)](https://opensource.org/licenses/Apache-2.0)
 [![GitHub Super-Linter](https://github.com/openconfig/gnsi/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
-
-# gNSI - gRPC Network Security Interface
 
 A repository which contains security infrastructure services
 necessary for safe operations of an OpenConfig platform. These

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gNSI - gRPC Network Security Interface
 
+[![GitHub Super-Linter](https://github.com/openconfig/gnsi/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+
 A repository which contains security infrastructure services
 necessary for safe operations of an OpenConfig platform. These
 services include:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# gNSI - gRPC Network Security Interface
-
+[![License: Apache](https://img.shields.io/badge/license-Apache%202-blue)](https://opensource.org/licenses/Apache-2.0)
 [![GitHub Super-Linter](https://github.com/openconfig/gnsi/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+
+# gNSI - gRPC Network Security Interface
 
 A repository which contains security infrastructure services
 necessary for safe operations of an OpenConfig platform. These

--- a/cert/index.md
+++ b/cert/index.md
@@ -73,7 +73,7 @@ cert.InstallCertificateRequest to the cert.Install rpc. The
 InstallCertificateRequest's install_request will be a
 cert.CertificateRevocationListBundle.
 
-Verify that the CRL newly deployed is usable by the relevant
+Optional, verify that the CRL newly deployed is usable by the relevant
 services.
 
 Send a cert.Finalize message to the cert.Install rpc to close

--- a/cert/index.md
+++ b/cert/index.md
@@ -1,0 +1,103 @@
+# gNSI cert Service Protobuf Definition
+**Contributors**: hines@google.com, morrowc@google.com, tmadejski@google.com
+**Last Updated**: 2022-07-12
+
+## Background
+
+The cert service definition provides the API to be used for installing,
+rotating, and testing PKI primatives used on network systems. The Rotate
+and Install are bidirectional streaming rpcs which permit mutating
+Certificates, Root Certificate Bundles, Certificate Revocation Lists.
+For either an Install or Rotate stream it is possible to mutate one or
+more of the elements, and to send a Finalize message once the in-flight
+change has been verified to be operational. Failure to send the Finalize
+message will result in the candidate element being discarded and the
+original element being used instead.
+
+## Motivation
+
+Management of the PKI elements for a network system should have
+a clear and direct method for installation and update.
+
+### CertificateManagement.Install
+
+CertificateManagemetn.Install will permit installation, and
+verification of function, of any of the PKI elements. The normal
+use-case would be to:
+
+* send an Certificate and Key to a network system as an
+InstallCertificateRequest.
+* verify that the services which will use the certificate continues
+to operate normally.
+* send a FinalizeRequest to finish the installation process.
+
+### CertificateManagement.Rotate
+
+CertificateManagement.Rotate will permit rotation, and
+verification of function, of any of the PKI elements.
+The normal use-case would be to:
+
+* send an CertificateBundle to a network system as a
+RotateCertificateRequest.
+* verify that the services which will use the new certificate bundle
+continue to operate normally.
+* send a FinalizeRequest to finish the rotateion process.
+
+## User Experiences
+
+### A Certificate is to be installed
+
+Create a new Certificate and Key.
+
+Send that certificate to the target network system with a
+cert.InstallCertificateRequest to the cert.Install rpc. The
+InstallCertificateRequest's install_request will be a
+cert.Certificate.
+
+Verify that the certificate newly deployed is usable by the relevant
+services, that the services properly present the certificate upon
+new service connections.
+
+Send a cert.Finalize message to the cert.Install rpc to close
+out the action.
+
+If the stream is disconnected prior to the Finalize message being
+sent, the proposed configuration is rolled back automatically.
+
+### A CertificateRevocationList is to be installed
+
+Create a new CertificateRevocationList (CRL).
+
+Send that certificate to the target network system with a
+cert.InstallCertificateRequest to the cert.Install rpc. The
+InstallCertificateRequest's install_request will be a
+cert.CertificateRevocationListBundle.
+
+Verify that the CRL newly deployed is usable by the relevant
+services.
+
+Send a cert.Finalize message to the cert.Install rpc to close
+out the action.
+
+If the stream is disconnected prior to the Finalize message being
+sent, the proposed configuration is rolled back automatically.
+
+### A CertificateBundle is to be rotated or updated
+
+Create, and test, a new CertificateBundle.
+
+Send that policy to the target network system with a
+cert.RotateCertificateRequest to cert.Rotate rpc. The
+RotateCertificateRequest's rotate_request will be a cert.CertificateBundle.
+
+Verify that the CertificateBundle newly rotated is used by services
+which require it.
+
+Send a Finalize message to the cert.Rotate rpc to close out the action.
+
+If the stream is disconnected prior to the Finalize message being
+sent, the proposed configuration is rolled back automatically.
+
+## Open Questions/Considerations
+
+None to date. 

--- a/cert/index.md
+++ b/cert/index.md
@@ -100,4 +100,4 @@ sent, the proposed configuration is rolled back automatically.
 
 ## Open Questions/Considerations
 
-None to date. 
+None to date.

--- a/cert/index.md
+++ b/cert/index.md
@@ -5,14 +5,14 @@
 ## Background
 
 The cert service definition provides the API to be used for installing,
-rotating, and testing PKI primatives used on network systems. The Rotate
-and Install are bidirectional streaming rpcs which permit mutating
-Certificates, Root Certificate Bundles, Certificate Revocation Lists.
-For either an Install or Rotate stream it is possible to mutate one or
-more of the elements, and to send a Finalize message once the in-flight
-change has been verified to be operational. Failure to send the Finalize
-message will result in the candidate element being discarded and the
-original element being used instead.
+rotating, deleting, and testing PKI primatives used on network systems.
+The Rotate and Install are bidirectional streaming rpcs which permit
+mutating Certificates, Root Certificate Bundles, Certificate Revocation
+Lists.  For either an Install or Rotate stream it is possible to mutate
+one or more of the elements, and to send a Finalize message once the
+in-flight change has been verified to be operational. Failure to send
+the Finalize message will result in the candidate element being discarded
+and the original element being used instead.
 
 ## Motivation
 
@@ -97,6 +97,25 @@ Send a Finalize message to the cert.Rotate rpc to close out the action.
 
 If the stream is disconnected prior to the Finalize message being
 sent, the proposed configuration is rolled back automatically.
+
+### A Certificate is rotated, the session breaks before Finalize
+
+Create a new Certificate and Key.
+
+Send that certificate to the target network system with a
+cert.InstallCertificateRequest to the cert.Install rpc. The
+InstallCertificateRequest's install_request will be a
+cert.Certificate.
+
+Verify that the certificate newly deployed is usable by the relevant
+services, that the services properly present the certificate upon
+new service connections.
+
+The connection to the network system is broken, there is no Finalize sent.
+
+The gNSI service rolls back the candidate and re-installs the original
+certificate and key.
+
 
 ## Open Questions/Considerations
 

--- a/pathz/README.md
+++ b/pathz/README.md
@@ -2,10 +2,10 @@
 
 ## `gnsi-pathz.yang`
 
-An overview of the changes defined in the `gnmi-pathz.yang ` file are shown
+An overview of the changes defined in the `gnmi-pathz.yang` file are shown
 below.
 
-```
+```sh
 module: gnsi-pathz
 
   augment /oc-sys:system:
@@ -24,12 +24,12 @@ module: gnsi-pathz
 
 ## `openconfig-system` tree
 
-The  `openconfig-system` sub-tree after augments defined in the
+The  `openconfig-system` subtree after augments defined in the
 `gnsi-pathz.yang` file is shown below.
 
 For interactive version click [here](gnsi-pathz.html).
 
-```
+```sh
 module: openconfig-system
   +--rw system
      +--rw config

--- a/pathz/README.md
+++ b/pathz/README.md
@@ -11,18 +11,15 @@ module: gnsi-pathz
   augment /oc-sys:system:
     +--ro gnmi-pathz-policies
        +--ro policies
-          +--ro policy* [id]
-             +--ro id       -> ../state/id
+          +--ro policy* [instance]
+             +--ro instance    -> ../state/instance
              +--ro state
-                +--ro id?           string
+                +--ro instance?     enumeration
                 +--ro version?      version
                 +--ro created-on?   created-on
-  augment /oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:config:
-    +--rw gnmi-pathz-policy-id?   string
   augment /oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state:
     +--ro gnmi-pathz-policy-version?      version
     +--ro gnmi-pathz-policy-created-on?   created-on
-    +--ro gnmi-pathz-policy-id?           string
 ```
 
 ## `openconfig-system` tree
@@ -446,7 +443,6 @@ module: openconfig-system
      |     |  +--rw oc-sys-grpc:metadata-authentication?   boolean
      |     |  +--rw oc-sys-grpc:listen-addresses*          union
      |     |  +--rw oc-sys-grpc:network-instance?          oc-ni:network-instance-ref
-     |     |  +--rw gnsi-pathz:gnmi-pathz-policy-id?       string
      |     +--ro oc-sys-grpc:state
      |        +--ro oc-sys-grpc:name?                          string
      |        +--ro oc-sys-grpc:services*                      identityref
@@ -459,13 +455,12 @@ module: openconfig-system
      |        +--ro oc-sys-grpc:network-instance?              oc-ni:network-instance-ref
      |        +--ro gnsi-pathz:gnmi-pathz-policy-version?      version
      |        +--ro gnsi-pathz:gnmi-pathz-policy-created-on?   created-on
-     |        +--ro gnsi-pathz:gnmi-pathz-policy-id?           string
      +--ro gnsi-pathz:gnmi-pathz-policies
         +--ro gnsi-pathz:policies
-           +--ro gnsi-pathz:policy* [id]
-              +--ro gnsi-pathz:id       -> ../state/id
+           +--ro gnsi-pathz:policy* [instance]
+              +--ro gnsi-pathz:instance    -> ../state/instance
               +--ro gnsi-pathz:state
-                 +--ro gnsi-pathz:id?           string
+                 +--ro gnsi-pathz:instance?     enumeration
                  +--ro gnsi-pathz:version?      version
                  +--ro gnsi-pathz:created-on?   created-on
 

--- a/pathz/gnsi-pathz.html
+++ b/pathz/gnsi-pathz.html
@@ -8089,27 +8089,6 @@ leafref
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:config/oc-sys-grpc:network-instance</td>
         </tr>
-        <tr id="1-1-16-42-64-77" class="a">
-        
-            <td nowrap>
-               <div id=9999 class=tier6>
-                  <a class="leaf">&nbsp;</a>
-                  <attr title="The ID of the OpenConfig-path-based authorization policy that
-is used by this gNMI server. The policy is provisioned
-through other interfaces to the device, such as the gNSI
-OpenConfig-path-based Authorization Policy management service."> <em> gnsi-pathz:gnmi-pathz-policy-id </em></abbr>
-            
-               </div>
-            </td> 
-        <td nowrap>leaf</td>
-        <td nowrap><abbr title="string
-">string</abbr></td>
-                
-        <td nowrap>config</td>
-        <td>?</td>
-        <td>current</td>
-        <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:config/gnsi-pathz:gnmi-pathz-policy-id</td>
-        </tr>
         <tr id="1-1-16-42-65" class="a">
         
             <td nowrap id="p4000">
@@ -8128,7 +8107,7 @@ OpenConfig-path-based Authorization Policy management service."> <em> gnsi-pathz
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state</td>
         </tr>
-        <tr id="1-1-16-42-65-78" class="a">
+        <tr id="1-1-16-42-65-77" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8147,7 +8126,7 @@ the local system."> <em> oc-sys-grpc:name </em></abbr>
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/oc-sys-grpc:name</td>
         </tr>
-        <tr id="1-1-16-42-65-79" class="a">
+        <tr id="1-1-16-42-65-78" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8174,7 +8153,7 @@ device.">  oc-sys-grpc:services </abbr>
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/oc-sys-grpc:services</td>
         </tr>
-        <tr id="1-1-16-42-65-80" class="a">
+        <tr id="1-1-16-42-65-79" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8193,7 +8172,7 @@ local device."> <em> oc-sys-grpc:enable </em></abbr>
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/oc-sys-grpc:enable</td>
         </tr>
-        <tr id="1-1-16-42-65-81" class="a">
+        <tr id="1-1-16-42-65-80" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8212,7 +8191,7 @@ uint16
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/oc-sys-grpc:port</td>
         </tr>
-        <tr id="1-1-16-42-65-82" class="a">
+        <tr id="1-1-16-42-65-81" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8232,7 +8211,7 @@ are not supported, such as lab testing."> <em> oc-sys-grpc:transport-security </
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/oc-sys-grpc:transport-security</td>
         </tr>
-        <tr id="1-1-16-42-65-83" class="a">
+        <tr id="1-1-16-42-65-82" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8252,7 +8231,7 @@ as the gNOI certificate management service."> <em> oc-sys-grpc:certificate-id </
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/oc-sys-grpc:certificate-id</td>
         </tr>
-        <tr id="1-1-16-42-65-84" class="a">
+        <tr id="1-1-16-42-65-83" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8273,7 +8252,7 @@ https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-authentication
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/oc-sys-grpc:metadata-authentication</td>
         </tr>
-        <tr id="1-1-16-42-65-85" class="a">
+        <tr id="1-1-16-42-65-84" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8292,7 +8271,7 @@ an IPv4 or an IPv6 address (or both).">  oc-sys-grpc:listen-addresses </abbr>
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/oc-sys-grpc:listen-addresses</td>
         </tr>
-        <tr id="1-1-16-42-65-86" class="a">
+        <tr id="1-1-16-42-65-85" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8312,7 +8291,7 @@ leafref
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/oc-sys-grpc:network-instance</td>
         </tr>
-        <tr id="1-1-16-42-65-87" class="a">
+        <tr id="1-1-16-42-65-86" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8332,7 +8311,7 @@ string
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/gnsi-pathz:gnmi-pathz-policy-version</td>
         </tr>
-        <tr id="1-1-16-42-65-88" class="a">
+        <tr id="1-1-16-42-65-87" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
@@ -8352,27 +8331,6 @@ oc-types:timeticks64
         <td>?</td>
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/gnsi-pathz:gnmi-pathz-policy-created-on</td>
-        </tr>
-        <tr id="1-1-16-42-65-89" class="a">
-        
-            <td nowrap>
-               <div id=9999 class=tier6>
-                  <a class="leaf">&nbsp;</a>
-                  <attr title="The ID of the OpenConfig-path-based authorization policy that
-is used by this gNMI server. The policy is provisioned
-through other interfaces to the device, such as the gNSI
-OpenConfig-path-based Authorization Policy management service."> <em> gnsi-pathz:gnmi-pathz-policy-id </em></abbr>
-            
-               </div>
-            </td> 
-        <td nowrap>leaf</td>
-        <td nowrap><abbr title="string
-">string</abbr></td>
-                
-        <td nowrap>no config</td>
-        <td>?</td>
-        <td>current</td>
-        <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/gnsi-pathz:gnmi-pathz-policy-id</td>
         </tr>
         <tr id="1-1-17" class="a">
         
@@ -8426,7 +8384,7 @@ authorization policy management service.">gnsi-pathz:policies</abbr>
                     class="folder">&nbsp;
                  </a>
                  <abbr title="Information about the OpenConfig-path-based authorization
-policy that is identified by the `id`.">gnsi-pathz:policy[id]</abbr>
+policy that is identified by the `instance`.">gnsi-pathz:policy[instance]</abbr>
               </div>
             </td>
         <td nowrap>list</td>
@@ -8436,26 +8394,26 @@ policy that is identified by the `id`.">gnsi-pathz:policy[id]</abbr>
         <td>current</td>
         <td nowrap>/oc-sys:system/gnsi-pathz:gnmi-pathz-policies/gnsi-pathz:policies/gnsi-pathz:policy</td>
         </tr>
-        <tr id="1-1-17-43-66-90" class="a">
+        <tr id="1-1-17-43-66-88" class="a">
         
             <td nowrap>
                <div id=9999 class=tier6>
                   <a class="leaf">&nbsp;</a>
                   <attr title="The ID of the OpenConfig-path-based authorization
-policy.">  gnsi-pathz:id </abbr>
+policy.">  gnsi-pathz:instance </abbr>
             
                </div>
             </td> 
         <td nowrap>leaf</td>
         <td nowrap><abbr title="leafref
- : ../state/id">leafref</abbr></td>
+ : ../state/instance">leafref</abbr></td>
                 
         <td nowrap>no config</td>
         <td></td>
         <td>current</td>
-        <td nowrap>/oc-sys:system/gnsi-pathz:gnmi-pathz-policies/gnsi-pathz:policies/gnsi-pathz:policy/gnsi-pathz:id</td>
+        <td nowrap>/oc-sys:system/gnsi-pathz:gnmi-pathz-policies/gnsi-pathz:policies/gnsi-pathz:policy/gnsi-pathz:instance</td>
         </tr>
-        <tr id="1-1-17-43-66-91" class="a">
+        <tr id="1-1-17-43-66-89" class="a">
         
             <td nowrap id="p4000">
                <div id="p5000" class="tier6">
@@ -8474,26 +8432,26 @@ authorization policies.">gnsi-pathz:state</abbr>
         <td>current</td>
         <td nowrap>/oc-sys:system/gnsi-pathz:gnmi-pathz-policies/gnsi-pathz:policies/gnsi-pathz:policy/gnsi-pathz:state</td>
         </tr>
-        <tr id="1-1-17-43-66-91-138" class="a">
+        <tr id="1-1-17-43-66-89-138" class="a">
         
             <td nowrap>
                <div id=9999 class=tier7>
                   <a class="leaf">&nbsp;</a>
-                  <attr title="The ID of the gNMI OpenConfig-path-based authorization
-policy."> <em> gnsi-pathz:id </em></abbr>
+                  <attr title="The instance identifier of the gNMI OpenConfig-path-based
+authorization policy."> <em> gnsi-pathz:instance </em></abbr>
             
                </div>
             </td> 
         <td nowrap>leaf</td>
-        <td nowrap><abbr title="string
-">string</abbr></td>
+        <td nowrap><abbr title="enumeration
+ : {ACTIVE,SANDBOX,}">enumeration</abbr></td>
                 
         <td nowrap>no config</td>
         <td>?</td>
         <td>current</td>
-        <td nowrap>/oc-sys:system/gnsi-pathz:gnmi-pathz-policies/gnsi-pathz:policies/gnsi-pathz:policy/gnsi-pathz:state/gnsi-pathz:id</td>
+        <td nowrap>/oc-sys:system/gnsi-pathz:gnmi-pathz-policies/gnsi-pathz:policies/gnsi-pathz:policy/gnsi-pathz:state/gnsi-pathz:instance</td>
         </tr>
-        <tr id="1-1-17-43-66-91-139" class="a">
+        <tr id="1-1-17-43-66-89-139" class="a">
         
             <td nowrap>
                <div id=9999 class=tier7>
@@ -8513,7 +8471,7 @@ string
         <td>current</td>
         <td nowrap>/oc-sys:system/gnsi-pathz:gnmi-pathz-policies/gnsi-pathz:policies/gnsi-pathz:policy/gnsi-pathz:state/gnsi-pathz:version</td>
         </tr>
-        <tr id="1-1-17-43-66-91-140" class="a">
+        <tr id="1-1-17-43-66-89-140" class="a">
         
             <td nowrap>
                <div id=9999 class=tier7>

--- a/pathz/gnsi-pathz.yang
+++ b/pathz/gnsi-pathz.yang
@@ -50,21 +50,6 @@ module gnsi-pathz {
 
     // gRPC server related definitions.
 
-    grouping grpc-server-gnmi-pathz-policy-config {
-        description
-            "OpenConfig-path-based-authorization-policy-related configuration
-            data for a gNMI server.";
-
-        leaf gnmi-pathz-policy-id {
-            type string;
-            description
-                "The ID of the OpenConfig-path-based authorization policy that
-                is used by this gNMI server. The policy is provisioned
-                through other interfaces to the device, such as the gNSI
-                OpenConfig-path-based Authorization Policy management service.";
-        }
-    }
-
     grouping grpc-server-gnmi-pathz-policy-state {
         description
             "gNMI server OpenConfig-path-based authorization policy
@@ -83,18 +68,32 @@ module gnsi-pathz {
                 authorization policy that is currently used by this gNMI server
                 was created.";
         }
-        uses grpc-server-gnmi-pathz-policy-config;
     }
 
     grouping gnmi-pathz-policy-state {
         description
             "Operational state data for a gNMI OpenConfig-path-based
             authorization policy.";
-        leaf id {
-            type string;
+        leaf instance {
+            type enumeration {
+                enum ACTIVE {
+                    value 1;
+                    description
+                        "The policy that is currently used by the gNMI service
+                        to authorize access.";
+                }
+                enum SANDBOX {
+                    value 2;
+                    description
+                        "The most recent policy that has been uploaded during
+                        the Rotation() RPC. If there is no Rotate() RPC in
+                        progress, then referring to this instance of the policy
+                        will result in an error.";
+                }
+            }
             description
-                "The ID of the gNMI OpenConfig-path-based authorization
-                policy.";
+                "The instance identifier of the gNMI OpenConfig-path-based
+                authorization policy.";
         }
         leaf version {
             type version;
@@ -128,14 +127,14 @@ module gnsi-pathz {
                  authorization policy management service.";
 
             list policy {
-                key id;
+                key instance;
                 ordered-by system;
                 description
                     "Information about the OpenConfig-path-based authorization
-                     policy that is identified by the `id`.";
-                leaf id {
+                     policy that is identified by the `instance`.";
+                leaf instance {
                     type leafref {
-                        path "../state/id";
+                        path "../state/instance";
                     }
                     description
                         "The ID of the OpenConfig-path-based authorization
@@ -184,15 +183,6 @@ module gnsi-pathz {
              and creation date/time listed.";
 
         uses system-gnmi-pathz-policies;
-    }
-    augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
-            "oc-sys-grpc:config" {
-        description
-            "Configuration of OpenConfig-path-based authorization policy used by
-             a gRPC server and managed by the gNSI OpenConfig-path-based
-             authorization policies management service.";
-
-        uses grpc-server-gnmi-pathz-policy-config;
     }
     augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
             "oc-sys-grpc:state" {

--- a/pathz/pathz.proto
+++ b/pathz/pathz.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Google Inc. All Rights Reserved.
+// Copyright 2021, 2022 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,15 +63,18 @@ service Pathz {
   //     Client <-- UploadResponse <--- Target
   //
   //   Step 3 (optional): Test/Validation by the client.
-  //     During this step client attempts to call a RPC that is allowed
-  //     in the new policy and validates that the new policy "works".
-  //     Additionally the client should access an OpenConfig path that is
-  //     not allowed and the attempt must fail proving that the OpenConfig
-  //     gNMI Path-based Authorization Policy "works".
+  //     During this step client calls (possibly multiple times)
+  //     the Probe(POLICY_INSTANCE_SANDBOX) RPC to check that a combination of
+  //     user ID, gNMI path and operation mode that is supposed to be allowed by
+  //     the new policy and validates that the response is ACTION_PERMIT.
+  //     Additionally the client should call the Probe(POLICY_INSTANCE_SANDBOX)
+  //     RPC with a combination of user ID, gNMI path and operation mode that is
+  //     not allowed in the new policy and the attempt must result in
+  //     the ACTION_DENY response proving that the new policy "works".
   //     Once verified, the client then proceeds to finalize the rotation.
-  //     If the verification did not succeed the client will cancel the
+  //     If the verification did not succeed the client will cancel the Rotate
   //     RPC thereby forcing the target to perform a rollback of the new
-  //     OpenConfig gNMI Path-based Authorization Policy.
+  //     OpenConfig gNMI Path-based Authorization Policy to the previous one.
   //
   //   Step 4: Final commit.
   //     Client ---> FinalizeRequest ----> Target
@@ -87,7 +90,7 @@ service Pathz {
 
   // Get returns specified instance of the OpenConfig gNMI Path-based
   // Authorization Policy together with its version and created-on information.
-  rpc Get(GetRequest) returns (GetRequest);
+  rpc Get(GetRequest) returns (GetResponse);
 }
 
 // Request messages to rotate existing OpenConfig gNMI Path-based Authorization

--- a/pathz/pathz.proto
+++ b/pathz/pathz.proto
@@ -113,10 +113,6 @@ message RotateRequest {
 
 // Response messages from the target.
 message RotateResponse {
-  // Response messages.
-  oneof rotate_response {
-    UploadResponse upload_response = 1;
-  }
 }
 
 // A Finalize message is sent to the target to confirm the rotation of

--- a/pathz/pathz.proto
+++ b/pathz/pathz.proto
@@ -164,16 +164,16 @@ message UploadResponse {
 enum PolicyInstance {
   // Invalid instance. Referring to this instance in any of the RPCs always
   // results in an error report.
-  UNSPECIFIED = 0;
+  POLICY_INSTANCE_UNSPECIFIED = 0;
 
   // The policy that is currently used by the gNMI service to authorize access.
-  ACTIVE = 1;
+  POLICY_INSTANCE_ACTIVE = 1;
 
   // The most recent policy that has been uploaded during the Rotation() RPC.
   // If there is no Rotate() RPC in progress, then referring to this instance
   // of the OpenConfig gNMI Path-based Authorization Policy will result in
   // an error.
-  SANDBOX = 2;
+  POLICY_INSTANCE_SANDBOX = 2;
 }
 
 // ProbeRequest contains a single user name and gNMI path being attempted.

--- a/pathz/pathz.proto
+++ b/pathz/pathz.proto
@@ -27,34 +27,29 @@ import "github.com/openconfig/gnsi/authorization/authorization.proto";
 option go_package = "github.com/openconfig/gnsi/pathz";
 option (gnoi.types.gnoi_version) = "0.1.0";
 
-// The OpenConfig Path-based Authz Policy Management Service exported by
-// targets.
+// The OpenConfig gNMI Path-based Authorization Policy Management Service
+// exported by targets.
 //
 
 // The OpenConfig Path-based Authorization Policy defines which principals
 // are permitted to access which OpenConfig path.
 
-// The service allows for installation of a policy using the Install() RPC and
-// then to change/update it using the Rotate() RPC.
-// There can be multiple polices installed on a target of which only one is
-// active and the rest are on-standby.
-// Activation of a standby policy is not handled by this service and is done
-// using the gNMI API.
+// The service allows for change/update of the OpenConfig Path-based
+// Authorization Policy using the Rotate() RPC.
+// There can be only one OpenConfig Path-based Authorization Policy installed on
+// a target.
 
 service Pathz {
 
-  // Rotate will replace an existing OpenConfig Path-based Authz Policy on
-  // the target.
+  // Rotate will replace an existing OpenConfig gNMI Path-based Authorization
+  // Policy on the target.
   // If the stream is broken or any of the steps fail the target must rollback
-  // to the original state, i.e. revert any changes to the OpenConfig Path-based
-  // Authz Policy made during this RPC.
+  // to the original state, i.e. revert any changes to the OpenConfig gNMI
+  // Path-based Authorization Policy made during this RPC.
   //
   // Note that only one such RPC can be in progress. An attempt to call this
   // RPC while another is already in progress will be rejected with the
   // `UNAVAILABLE` gRPC error.
-  //
-  // An attempt to rotate a policy with not exisitng `id` will be rejected
-  // with the `FAILED_PRECONDITION` gRPC error.
   //
   // The following describes the sequence of messages that must be exchanged
   // in the Rotate() RPC.
@@ -63,7 +58,7 @@ service Pathz {
   //   Step 1: Start the stream
   //     Client ----> Rotate() RPC stream begin ------> Target
   //
-  //   Step 2: Send OpenConfig Path-based Authz Policy to Target.
+  //   Step 2: Send OpenConfig gNMI Path-based Authorization Policy to Target.
   //     Client --> UploadRequest(pathz_policy) ----> Target
   //     Client <-- UploadResponse <--- Target
   //
@@ -72,60 +67,32 @@ service Pathz {
   //     in the new policy and validates that the new policy "works".
   //     Additionally the client should access an OpenConfig path that is
   //     not allowed and the attempt must fail proving that the OpenConfig
-  //     Path-based Authz Policy "works".
-  //     Once verfied, the client then proceeds to finalize the rotation.
-  //     If the new verification did not succeed the client will cancel the
+  //     gNMI Path-based Authorization Policy "works".
+  //     Once verified, the client then proceeds to finalize the rotation.
+  //     If the verification did not succeed the client will cancel the
   //     RPC thereby forcing the target to perform a rollback of the new
-  //     OpenConfig Path-based Authz Policy.
+  //     OpenConfig gNMI Path-based Authorization Policy.
   //
   //   Step 4: Final commit.
   //     Client ---> FinalizeRequest ----> Target
   //
-  rpc Rotate(stream RotatePathzRequest)
-      returns (stream RotatePathzResponse);
-
-  // Install will add a new OpenConfig Path-based Authz Policy on the target.
-  // If the stream is broken or any of the steps fail the target must rollback
-  // to the original state, i.e. revert any changes to the OpenConfig Path-based
-  // Authz Policy made during this RPC.
-  //
-  // Note that only one such RPC can be in progress. An attempt to call this
-  // RPC while another is already in progress will be rejected with the
-  // `UNAVAILABLE gRPC` error.
-  //
-  // An attempt to install a policy with already existing `id` will be rejected
-  // with the `ALREADY_EXISTS` gRPC error.
-  //
-  // As a policy has to be installed on a target before it is activated using
-  // the gNMI API it cannot be tested after uploading.
-  //
-  // The following describes the sequence of messages that must be exchanged
-  // in the Install() RPC.
-  //
-  // Sequence of expected messages:
-  //   Step 1: Start the stream
-  //     Client ----> Install() RPC stream begin ------> Target
-  //
-  //   Step 2: Send OpenConfig Path-based Authz Policy to Target.
-  //     Client --> UploadRequest(pathz_policy) ----> Target
-  //     Client <-- UploadResponse <--- Target
-  //
-  //   Step 3: Final commit.
-  //     Client ---> FinalizeRequest ----> Target
-  //
-  rpc Install(stream InstallPathzRequest)
-      returns (stream InstallPathzResponse);
+  rpc Rotate(stream RotateRequest)
+      returns (stream RotateResponse);
 
   // Probe allows for evaluation of the pathz policy engine response to a gNMI
   // operation performed by a user on a single gNMI path.
-  // The response is based on the currently active policy and is evaluated
-  // without actually performing the gNMI operation.
+  // The response is based on the instance of policy specified in the request
+  // and is evaluated without actually performing the gNMI operation.
   rpc Probe(ProbeRequest) returns (ProbeResponse);
+
+  // Get returns specified instance of the OpenConfig gNMI Path-based
+  // Authorization Policy together with its version and created-on information.
+  rpc Get(GetRequest) returns (GetRequest);
 }
 
-// Request messages to rotate existing OpenConfig Path-based Authz Policy on
-// the target.
-message RotatePathzRequest {
+// Request messages to rotate existing OpenConfig gNMI Path-based Authorization
+// Policy on the target.
+message RotateRequest {
   // Request Messages.
   oneof rotate_request {
     UploadRequest upload_request = 1;
@@ -142,49 +109,28 @@ message RotatePathzRequest {
 }
 
 // Response messages from the target.
-message RotatePathzResponse {
+message RotateResponse {
   // Response messages.
   oneof rotate_response {
     UploadResponse upload_response = 1;
   }
 }
 
-// Request messages to install a new OpenConfig Path-based Authz Policy on
-// the target.
-message InstallPathzRequest {
-  // Request Messages.
-  oneof install_request {
-    UploadRequest upload_request = 1;
-    FinalizeRequest finalize_installation = 2;
-  }
-}
-
-// Response messages from the target.
-message InstallPathzResponse {
-  // Response messages.
-  oneof install_response {
-    UploadResponse upload_response = 1;
-  }
-}
-
 // A Finalize message is sent to the target to confirm the rotation of
-// the OpenConfig Path-based Authz Policy and that it should not be rolled back
-// when the RPC concludes.
-// Note that the OpenConfig Path-based Authz Policy change is considered rolled
-// back by the target if the target returns an error as response to
-// the Finalize message.
+// the OpenConfig gNMI Path-based Authorization Policy and that it should not be
+// rolled back when the RPC concludes.
+// Note that the OpenConfig gNMI Path-based Authorization Policy change is
+// considered rolled back by the target if the target returns an error as
+// response to the Finalize message.
 message FinalizeRequest {
 }
 
-// UploadRequest instructs the target to store the given OpenConfig Path-based
-// Authz Policy.
+// UploadRequest instructs the target to store the given OpenConfig gNMI Path-
+// based Authorization Policy.
 //
 // If there is another ongoing Rotate RPC the UploadRequest must fail.
 //
 message UploadRequest {
-  // Policy ID. The ID is used to identify the policy in the gNMI API.
-  string id = 1;
-
   // `version` contains versioning information that is controlled by
   // the policy manager and reported as-is by the telemetry reporting system
   // (ie, transparent to the target policy management service). Policy managers
@@ -194,7 +140,8 @@ message UploadRequest {
   // a particular switch). Also, such version string should be persisted by
   // the device onto non-volatile memory for preservation across system
   // reboots.
-  string version = 2;
+  string version = 1;
+
   // `created_on` contains information when the policy was created.
   // This information is controlled by the policy manager and reported as-is
   // by the telemetry reporting system (ie, transparent to the device policy
@@ -205,27 +152,89 @@ message UploadRequest {
   // memory for preservation across system reboots.
   // `created_on` is a timestamp: the number of seconds since
   // January 1st, 1970 00:00:00 GMT a.k.a. unix epoch.
-  uint64 created_on = 3;
+  uint64 created_on = 2;
 
-  // The actual OpenConfig Path-based Authz Policy.
-  gnsi.authorization.AuthorizationPolicy policy = 4;
+  // The actual OpenConfig gNMI Path-based Authorization Policy.
+  gnsi.authorization.AuthorizationPolicy policy = 3;
 }
 
 message UploadResponse {
 }
 
-// ProbeRequest contains a single user name and gNMI Path being attempted.
-// Data returned to an RPC Caller should adhere to the policy.
-message ProbeRequest {
-  string user = 1;
-  gnmi.Path path = 2;
+enum PolicyInstance {
+  // Invalid instance. Referring to this instance in any of the RPCs always
+  // results in an error report.
+  UNSPECIFIED = 0;
+
+  // The policy that is currently used by the gNMI service to authorize access.
+  ACTIVE = 1;
+
+  // The most recent policy that has been uploaded during the Rotation() RPC.
+  // If there is no Rotate() RPC in progress, then referring to this instance
+  // of the OpenConfig gNMI Path-based Authorization Policy will result in
+  // an error.
+  SANDBOX = 2;
 }
 
-// ProbeResponse returns the ack/nack for a single user request
-// as evaluated against the current policy, along with the policy ID
-// and current policy version.
+// ProbeRequest contains a single user name and gNMI path being attempted.
+// Data returned to an RPC caller should adhere to the policy.
+message ProbeRequest {
+  // The user name to be used to perform the evaluation.
+  string user = 1;
+
+  // The gNMI path to be used to perform the evaluation.
+  gnmi.Path path = 2;
+
+  // The operation type (read or write) to be used to perform the evaluation.
+  gnsi.authorization.Mode mode = 3;
+
+  // The instance of the OpenConfig gNMI Path-based Authorization Policy to be
+  // used to perform the evaluation.
+  PolicyInstance policy_instance = 4;
+}
+
+// ProbeResponse returns the ACK/NACK for a single user request
+// as evaluated against the current policy, along with the version of the policy
+// that the gNMI path/user were evaluated against.
 message ProbeResponse {
   gnsi.authorization.Action action = 1;
-  string id = 2;
-  string version = 3;
+  string version = 2;
+}
+
+// GetRequest specifies which instance of the OpenConfig gNMI Path-based
+// Authorization Policy is to be returned to the caller.
+message GetRequest {
+  // The instance of the OpenConfig gNMI Path-based Authorization Policy to be
+  // returned to the caller.
+  PolicyInstance policy_instance = 1;
+}
+
+// GetResponse returns the requested instance of the OpenConfig gNMI Path-based
+// Authorization Policy together with `version` and `created_on` information.
+message GetResponse {
+  // `version` contains versioning information that is controlled by
+  // the policy manager and reported as-is by the telemetry reporting system
+  // (ie, transparent to the target policy management service). Policy managers
+  // should choose version strings as discrete as possible to ease alert
+  // generation (eg, for policies sourced from a bundle, the timestamp of
+  // the bundle should be used but not the time when the policy is pushed to
+  // a particular switch). Also, such version string should be persisted by
+  // the device onto non-volatile memory for preservation across system
+  // reboots.
+  string version = 1;
+
+  // `created_on` contains information when the policy was created.
+  // This information is controlled by the policy manager and reported as-is
+  // by the telemetry reporting system (ie, transparent to the device policy
+  // management service). Policy manager should use the timestamp of the moment
+  // when policy was created, not the time when the policy is pushed to
+  // a particular switch).
+  // Also, this timestamp should be persisted by the device onto non-volatile
+  // memory for preservation across system reboots.
+  // `created_on` is a timestamp: the number of seconds since
+  // January 1st, 1970 00:00:00 GMT a.k.a. unix epoch.
+  uint64 created_on = 2;
+
+  // The actual OpenConfig gNMI Path-based Authorization Policy.
+  gnsi.authorization.AuthorizationPolicy policy = 3;
 }


### PR DESCRIPTION
* Removes Install()
* Adds Get()
* Adds PolicyInstance enum and adds its use to Probe() and Get()
* Removes 'Pathz' from RotatePathz{Request|Response}