### PR TITLE
Fixes wording in description of pathz policy identifier.

### DIFF
--- a/pathz/README.md
+++ b/pathz/README.md
@@ -2,12 +2,13 @@
 
 ## Yang schema
 
+## `gnsi-pathz` tree
 <details>
-  <summary>
- `gnsi-pathz.yang`
+<summary>
 
 An overview of the changes defined in the `gnmi-pathz.yang` file are shown
-below.</summary>
+below.
+</summary>
 
 ```sh
 module: gnsi-pathz
@@ -27,10 +28,13 @@ module: gnsi-pathz
 ```
 </details>
 
-### `openconfig-system` tree
+## `openconfig-system` tree
+<details>
+<summary>
 
 The  `openconfig-system` subtree after augments defined in the
 `gnsi-pathz.yang` file is shown below.
+</summary>
 
 For interactive version click [here](gnsi-pathz.html).
 
@@ -470,3 +474,4 @@ module: openconfig-system
                  +--ro gnsi-pathz:created-on?   created-on
 
 ```
+</details>

--- a/pathz/README.md
+++ b/pathz/README.md
@@ -6,7 +6,7 @@
 <details>
 <summary>
 
-An overview of the changes defined in the `gnmi-pathz.yang` file are shown
+An overview of the changes defined in the `gnsi-pathz.yang` file are shown
 below.
 </summary>
 

--- a/pathz/gnsi-pathz.html
+++ b/pathz/gnsi-pathz.html
@@ -8343,8 +8343,9 @@ oc-types:timeticks64
                  <abbr title="Collection of OpenConfig-path-based authorization policies that
 have been installed on the device using the gNSI OpenConfig-
 path-based authorization policy management service.
-Each policy listed here is identified by an ID and has its
-version and creation date/time listed.">gnsi-pathz:gnmi-pathz-policies</abbr>
+Each policy listed here is identified by its status (either
+ACTIVE or SANDBOX) and has its version and creation date/time
+listed.">gnsi-pathz:gnmi-pathz-policies</abbr>
               </div>
             </td>
         <td nowrap>container</td>

--- a/pathz/gnsi-pathz.yang
+++ b/pathz/gnsi-pathz.yang
@@ -115,8 +115,8 @@ module gnsi-pathz {
              have been installed on the device using the gNSI OpenConfig-path-
              based authorization policy management service.
              Each OpenConfig-path-based authorization policy listed here is
-             identified by an ID and has its version and creation date/time
-             listed.";
+             identified by its status (either ACTIVE or SANDBOX) and has its
+             version and creation date/time listed.";
 
         container policies {
             config false;
@@ -156,8 +156,8 @@ module gnsi-pathz {
             "Collection of OpenConfig-path-based authorization policies that
              have been installed on the device using the gNSI OpenConfig-path-
              based authorization policy management service.
-             Each policy listed here is identified by an ID and has its version
-             and creation date/time listed.";
+             Each policy listed here is identified by its status (either ACTIVE
+             or SANDBOX) and has its version and creation date/time listed.";
 
         container gnmi-pathz-policies {
             config false;
@@ -165,8 +165,9 @@ module gnsi-pathz {
                 "Collection of OpenConfig-path-based authorization policies that
                 have been installed on the device using the gNSI OpenConfig-
                 path-based authorization policy management service.
-                Each policy listed here is identified by an ID and has its
-                version and creation date/time listed.";
+                Each policy listed here is identified by its status (either
+                ACTIVE or SANDBOX) and has its version and creation date/time
+                listed.";
 
             uses gnmi-pathz-policies;
         }
@@ -179,8 +180,8 @@ module gnsi-pathz {
             "Collection of OpenConfig-path-based authorization policies that
              have been installed on the device using the gNSI OpenConfig-path-
              based authorization policy management service.
-             Each policy listed here is identified by an ID and has its version
-             and creation date/time listed.";
+             Each policy listed here is identified by its status (either ACTIVE
+             or SANDBOX) and has its version and creation date/time listed.";
 
         uses system-gnmi-pathz-policies;
     }


### PR DESCRIPTION
Replaced ID with type of instance (ACTIVE or SANDBOX) in descriptions.