### PR TITLE
authz: clarify Rule name field in README

### DIFF
--- a/authz/README.md
+++ b/authz/README.md
@@ -97,6 +97,7 @@ message Request {
 message Rule {
   // Required. The name of an authorization rule.
   // It is mainly for monitoring and error message generation.
+  // This name must be unique within the list of deny (or allow) rules. 
   string name = 1;
 
   // Optional. If not set, no checks will be performed against the source. An


### PR DESCRIPTION
Clarify that the name field in the Rule message should be unique.

As defined in
https://github.com/grpc/proposal/blob/master/A43-grpc-authorization-api.md#proposal