### PR TITLE
Add boolean *_istrunctated fields corresponding to

### DIFF
--- a/accounting/acct.proto
+++ b/accounting/acct.proto
@@ -150,8 +150,16 @@ message CommandService {
   // The command that was executed.
   string cmd = 2;
 
+  // True, if truncation of cmd occurs due to an implementation
+  // limitation in the originating service, any middleware, or the receiver.
+  bool cmd_istruncated = 4;
+
   // Arguments to a command above.
   repeated string cmd_args = 3;
+
+  // True, if truncation of cmd_args occurs due to an implementation
+  // limitation in the originating service, any middleware, or the receiver.
+  bool cmd_args_istruncated = 5;
 }
 
 // Command details for openconfig gNxI commands.
@@ -179,9 +187,17 @@ message GrpcService {
   // PROTO_ANY.
   repeated google.protobuf.Any payloads = 3;
 
+  // True, if truncation of payloads occurs due to an implementation
+  // limitation in the originating service, any middleware, or the receiver.
+  bool payload_istruncated = 5;
+
   // config_metadata can be used to track all set requests that were to be
   // applied atomically.
   string config_metadata = 4;
+
+  // True, if truncation of config_metadata occurs due to an implementation
+  // limitation in the originating service, any middleware, or the receiver.
+  bool metadata_istruncated = 6;
 }
 
 // An accounting record message is generated everytime the user types a


### PR DESCRIPTION
accounting.CommandService.cmd{_args} and
accounting.GrpcService.{payloads,config_metadata} to indicate that the fields were truncates due to implementation limitations.

fixes #96