### PR TITLE
"switch" -> "device"

### DIFF
--- a/certz/certz.proto
+++ b/certz/certz.proto
@@ -494,22 +494,20 @@ message Entity {
   // the credential manager and reported as-is by the telemetry reporting system
   // (ie, transparent to the device credential service).  Credential managers
   // should choose version strings as discrete as possible to ease alert
-  // generation (eg, for credentials sourced from a bundle, the timestamp of
-  // the bundle should be used but not the time when the credential is pushed to
-  // a particular switch).  Also, such version strings should be persisted by
-  // the devices onto non-volatile memory for preservation across system
-  // reboots.
+  // generation.
+  // Also, this version string must be persisted by the device for preservation
+  // across system reboots / cold-starts.
   string version = 1;
   // `created_on` contains information when the credentials were created.
   // This information is controlled by the credential manager and reported as-is
   // by the telemetry reporting system (ie, transparent to the device credential
   // service).  Credential managers should use the timestamp of the moment when
   // credential was created, not the time when the credential is pushed to
-  // a particular switch).
-  // Also, this timestamp should be persisted by the devices onto non-volatile
-  // memory for preservation across system reboots.
+  // a particular device).
+  // Also, this timestamp must be persisted by the device for preservation
+  // across system reboots / cold-starts.
   // `created_on` is a timestamp: the number of seconds since
-  // January 1st, 1970 00:00:00 GMT.
+  // January 1st, 1970 00:00:00 GMT, a.k.a. unix epoch.
   uint64 created_on = 2;
 
   oneof entity {

--- a/credentialz/credentialz.proto
+++ b/credentialz/credentialz.proto
@@ -190,13 +190,13 @@ service Credentialz {
   //   Step 4: Final commit.
   //     Client -----> FinalizeRequest----> Target
   //
-  //   Use Case 3: Replace keys by generating on the switch
+  //   Use Case 3: Replace keys by generating on the device
   //
   //     Step 1: Start the stream
   //       Client <---- RotateHostParameters() RPC stream begin ------> Target
   //
-  //     Step 2: Trigger key generation on the switch and apply host key. The
-  //             switch returns the public keys corresponding to the generated
+  //     Step 2: Trigger key generation on the device and apply host key. The
+  //             device returns the public keys corresponding to the generated
   //             private keys which will be used to create host certificates.
   //       Client -----> GenerateKeysRequest ----> Target
   //       Client <----  GenerateKeysResponse <----- Target
@@ -451,22 +451,20 @@ message AccountCredentials {
   // the credential manager and reported as-is by the telemetry reporting system
   // (ie, transparent to the device credential service).  Credential managers
   // should choose version strings as discrete as possible to ease alert
-  // generation (eg, for credentials sourced from a bundle, the timestamp of
-  // the bundle should be used but not the time when the credential is pushed to
-  // a particular switch).  Also, such version strings should be persisted by
-  // the devices onto non-volatile memory for preservation across system
-  // reboots.
+  // generation.
+  // Also, this version string must be persisted by the device for preservation
+  // across system reboots / cold-starts.
   string version = 3;
   // `created_on` contains information when the credentials were created.
   // This information is controlled by the credential manager and reported as-is
   // by the telemetry reporting system (ie, transparent to the device credential
   // service).  Credential managers should use the timestamp of the moment when
   // credential was created, not the time when the credential is pushed to
-  // a particular switch).
-  // Also, this timestamp should be persisted by the devices onto non-volatile
-  // memory for preservation across system reboots.
+  // a particular device).
+  // Also, this timestamp must be persisted by the device for preservation
+  // across system reboots / cold-starts.
   // `created_on` is a timestamp: the number of seconds since
-  // January 1st, 1970 00:00:00 GMT.
+  // January 1st, 1970 00:00:00 GMT, a.k.a. unix epoch.
   uint64 created_on = 4;
 }
 
@@ -506,22 +504,20 @@ message UserPolicy {
   // the credential manager and reported as-is by the telemetry reporting system
   // (ie, transparent to the device credential service).  Credential managers
   // should choose version strings as discrete as possible to ease alert
-  // generation (eg, for credentials sourced from a bundle, the timestamp of
-  // the bundle should be used but not the time when the credential is pushed to
-  // a particular switch).  Also, such version strings should be persisted by
-  // the devices onto non-volatile memory for preservation across system
-  // reboots.
+  // generation.
+  // Also, this version string must be persisted by the device for preservation
+  // across system reboots / cold-starts.
   string version = 4;
   // `created_on` contains information when the credentials were created.
   // This information is controlled by the credential manager and reported as-is
   // by the telemetry reporting system (ie, transparent to the device credential
   // service).  Credential managers should use the timestamp of the moment when
   // credential was created, not the time when the credential is pushed to
-  // a particular switch).
-  // Also, this timestamp should be persisted by the devices onto non-volatile
-  // memory for preservation across system reboots.
+  // a particular device).
+  // Also, this timestamp must be persisted by the device for preservation
+  // across system reboots / cold-starts.
   // `created_on` is a timestamp: the number of seconds since
-  // January 1st, 1970 00:00:00 GMT.
+  // January 1st, 1970 00:00:00 GMT, a.k.a. unix epoch.
   uint64 created_on = 5;
 }
 
@@ -556,22 +552,20 @@ message PasswordRequest {
     // the credential manager and reported as-is by the telemetry reporting
     // system (ie, transparent to the device credential service).  Credential
     // managers should choose version strings as discrete as possible to ease
-    // alert generation (eg, for credentials sourced from a bundle,
-    // the timestamp of the bundle should be used but not the time when
-    // the credential is pushed to a particular switch).  Also, such version
-    // strings should be persisted by the devices onto non-volatile memory for
-    // preservation across system reboots.
+    // alert generation.
+    // Also, this version string must be persisted by the device for
+    // preservation across system reboots / cold-starts.
     string version = 3;
     // `created_on` contains information when the credentials were created.
     // This information is controlled by the credential manager and reported
     // as-is by the telemetry reporting system (ie, transparent to the device
     // credential service).  Credential managers should use the timestamp of
     // the moment when credential was created, not the time when the credential
-    // is pushed to a particular switch).
-    // Also, this timestamp should be persisted by the devices onto non-volatile
-    // memory for preservation across system reboots.
+    // is pushed to a particular device).
+    // Also, this timestamp must be persisted by the device for preservation
+    // across system reboots / cold-starts.
     // `created_on` is a timestamp: the number of seconds since
-    // January 1st, 1970 00:00:00 GMT.
+    // January 1st, 1970 00:00:00 GMT, a.k.a. unix epoch.
     uint64 created_on = 4;
   }
   repeated Account accounts = 1;
@@ -652,22 +646,20 @@ message CaPublicKeyRequest {
   // the credential manager and reported as-is by the telemetry reporting system
   // (ie, transparent to the device credential service).  Credential managers
   // should choose version strings as discrete as possible to ease alert
-  // generation (eg, for credentials sourced from a bundle, the timestamp of
-  // the bundle should be used but not the time when the credential is pushed to
-  // a particular switch).  Also, such version strings should be persisted by
-  // the devices onto non-volatile memory for preservation across system
-  // reboots.
+  // generation.
+  // Also, this version string must be persisted by
+  // the device for preservation across system reboots / cold-starts.
   string version = 2;
   // `created_on` contains information when the credentials were created.
   // This information is controlled by the credential manager and reported as-is
   // by the telemetry reporting system (ie, transparent to the device credential
   // service).  Credential managers should use the timestamp of the moment when
   // credential was created, not the time when the credential is pushed to
-  // a particular switch).
-  // Also, this timestamp should be persisted by the devices onto non-volatile
-  // memory for preservation across system reboots.
+  // a particular device).
+  // Also, this timestamp must be persisted by the device for preservation
+  // across system reboots / cold-starts.
   // `created_on` is a timestamp: the number of seconds since
-  // January 1st, 1970 00:00:00 GMT.
+  // January 1st, 1970 00:00:00 GMT, a.k.a. unix epoch.
   uint64 created_on = 3;
 }
 
@@ -721,22 +713,20 @@ message ServerKeysRequest {
   // the credential manager and reported as-is by the telemetry reporting system
   // (ie, transparent to the device credential service).  Credential managers
   // should choose version strings as discrete as possible to ease alert
-  // generation (eg, for credentials sourced from a bundle, the timestamp of
-  // the bundle should be used but not the time when the credential is pushed to
-  // a particular switch).  Also, such version strings should be persisted by
-  // the devices onto non-volatile memory for preservation across system
-  // reboots.
+  // generation.
+  // Also, this version string must be persisted by
+  // the device for preservation across system reboots / cold-starts.
   string version = 2;
   // `created_on` contains information when the credentials were created.
   // This information is controlled by the credential manager and reported as-is
   // by the telemetry reporting system (ie, transparent to the device credential
   // service).  Credential managers should use the timestamp of the moment when
   // credential was created, not the time when the credential is pushed to
-  // a particular switch).
-  // Also, this timestamp should be persisted by the devices onto non-volatile
-  // memory for preservation across system reboots.
+  // a particular device).
+  // Also, this timestamp must be persisted by the device for preservation
+  // across system reboots / cold-starts.
   // `created_on` is a timestamp: the number of seconds since
-  // January 1st, 1970 00:00:00 GMT.
+  // January 1st, 1970 00:00:00 GMT, a.k.a. unix epoch.
   uint64 created_on = 3;
 }
 

--- a/pathz/pathz.proto
+++ b/pathz/pathz.proto
@@ -135,11 +135,9 @@ message UploadRequest {
   // the policy manager and reported as-is by the telemetry reporting system
   // (ie, transparent to the target policy management service). Policy managers
   // should choose version strings as discrete as possible to ease alert
-  // generation (eg, for policies sourced from a bundle, the timestamp of
-  // the bundle should be used but not the time when the policy is pushed to
-  // a particular switch). Also, such version string should be persisted by
-  // the device onto non-volatile memory for preservation across system
-  // reboots.
+  // generation.
+  // Also, this version string must be persisted by
+  // the device for preservation across system reboots / cold-starts.
   string version = 1;
 
   // `created_on` contains information when the policy was created.
@@ -147,11 +145,11 @@ message UploadRequest {
   // by the telemetry reporting system (ie, transparent to the device policy
   // management service). Policy manager should use the timestamp of the moment
   // when policy was created, not the time when the policy is pushed to
-  // a particular switch).
-  // Also, this timestamp should be persisted by the device onto non-volatile
-  // memory for preservation across system reboots.
+  // a particular device).
+  // Also, this timestamp must be persisted by the device for preservation
+  // across system reboots / cold-starts.
   // `created_on` is a timestamp: the number of seconds since
-  // January 1st, 1970 00:00:00 GMT a.k.a. unix epoch.
+  // January 1st, 1970 00:00:00 GMT, a.k.a. unix epoch.
   uint64 created_on = 2;
 
   // The actual OpenConfig gNMI Path-based Authorization Policy.
@@ -216,11 +214,9 @@ message GetResponse {
   // the policy manager and reported as-is by the telemetry reporting system
   // (ie, transparent to the target policy management service). Policy managers
   // should choose version strings as discrete as possible to ease alert
-  // generation (eg, for policies sourced from a bundle, the timestamp of
-  // the bundle should be used but not the time when the policy is pushed to
-  // a particular switch). Also, such version string should be persisted by
-  // the device onto non-volatile memory for preservation across system
-  // reboots.
+  // generation.
+  // Also, this version string must be persisted by
+  // the device for preservation across system reboots / cold-starts.
   string version = 1;
 
   // `created_on` contains information when the policy was created.
@@ -228,11 +224,11 @@ message GetResponse {
   // by the telemetry reporting system (ie, transparent to the device policy
   // management service). Policy manager should use the timestamp of the moment
   // when policy was created, not the time when the policy is pushed to
-  // a particular switch).
-  // Also, this timestamp should be persisted by the device onto non-volatile
-  // memory for preservation across system reboots.
+  // a particular device).
+  // Also, this timestamp should be persisted by the device for preservation
+  // across system reboots / cold-starts.
   // `created_on` is a timestamp: the number of seconds since
-  // January 1st, 1970 00:00:00 GMT a.k.a. unix epoch.
+  // January 1st, 1970 00:00:00 GMT, a.k.a. unix epoch.
   uint64 created_on = 2;
 
   // The actual OpenConfig gNMI Path-based Authorization Policy.


### PR DESCRIPTION
GC duplicated text about created_on timestamp source. As in MR#101, version and created_on values must be preserved; use the same text in all instances.