### PR TITLE
Explain that config_metadata should be a transactional UUID, allowing…

### DIFF
--- a/acctz/acctz.proto
+++ b/acctz/acctz.proto
@@ -183,7 +183,8 @@ message GrpcService {
   bool payload_istruncated = 5;
 
   // config_metadata can be used to track all set requests that were to be
-  // applied atomically.
+  // applied atomically.  It should contain a per-transaction (1 per stream)
+  // UUID.
   string config_metadata = 4;
 
   // True, if truncation of config_metadata occurs due to an implementation

--- a/acctz/acctz.proto
+++ b/acctz/acctz.proto
@@ -181,15 +181,6 @@ message GrpcService {
   // True, if truncation of payloads occurs due to an implementation
   // limitation in the originating service, any middleware, or the receiver.
   bool payload_istruncated = 5;
-
-  // config_metadata can be used to track all set requests that were to be
-  // applied atomically.  It should contain a per-transaction (1 per stream)
-  // UUID.
-  string config_metadata = 4;
-
-  // True, if truncation of config_metadata occurs due to an implementation
-  // limitation in the originating service, any middleware, or the receiver.
-  bool metadata_istruncated = 6;
 }
 
 // An accounting record message is generated everytime the user types a


### PR DESCRIPTION
… all

gRPC of a transaction to be correlated.
Address issue #92