### PR TITLE
Remove ServiceStatus after further discussion with mschleifer.  These…

### DIFF
--- a/acctz/acctz.proto
+++ b/acctz/acctz.proto
@@ -175,17 +175,6 @@ message GrpcService {
   // True, if truncation of payloads occurs due to an implementation
   // limitation in the originating service, any middleware, or the receiver.
   bool payload_istruncated = 5;
-
-  // Service processing status at the time of event reporting.
-  enum ServiceStatus {
-    SERVICE_STATUS_UNSPECIFIED = 0;
-    SERVICE_STATUS_SUCCESS = 1;
-    SERVICE_STATUS_FAILURE = 2;
-  }
-  ServiceStatus status = 6;
-
-  // If status == SERVICE_STATUS_FAILURE, cause for the failure
-  string failure_cause = 7;
 }
 
 // An accounting record message is generated everytime the user types a


### PR DESCRIPTION
… are

accounting records, not syslog or debugging, and the status of the RPC itself is not an accouting function.