### PR TITLE
Fix the canonical order of "config" statement

### DIFF
--- a/credentialz/gnsi-credentialz.yang
+++ b/credentialz/gnsi-credentialz.yang
@@ -22,6 +22,12 @@ module gnsi-credentialz {
         "This module provides a data model for the metadata of SSH and console
          credentials installed on a networking device.";
 
+    revision 2023-08-18 {
+        description
+            "Fixed the canonical order of config field.";
+        reference "0.3.0";
+    }
+
     revision 2022-10-30 {
         description
             "Adds success/failure counters.";
@@ -182,9 +188,9 @@ module gnsi-credentialz {
             }
 
             container state {
+                config false;
                 description
                     "Console-related state.";
-                config false;
 
                 uses counters;
             }


### PR DESCRIPTION
Fixed the order of `config` statement according to RFC 6020, Section 12