### PR TITLE
certz: add ssl-profile-id leaf

### DIFF
--- a/certz/README.md
+++ b/certz/README.md
@@ -54,7 +54,7 @@ When no longer a profile is needed it can be removed from the target via
 `Certz.DeleteProfile()` RPC. Note that the gNxI SSL profile cannot be
 removed.
 
-The SSL profile ID of a gRPC server is exposed in the YANG leaf 
+The SSL profile ID of a gRPC server is exposed in the YANG leaf
 `ssl-profile-id` which is an augment to the
 `/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state`
 container.

--- a/certz/README.md
+++ b/certz/README.md
@@ -54,6 +54,11 @@ When no longer a profile is needed it can be removed from the target via
 `Certz.DeleteProfile()` RPC. Note that the gNxI SSL profile cannot be
 removed.
 
+The SSL profile ID of a gRPC server is exposed in the YANG leaf 
+`ssl-profile-id` which is an augment to the
+`/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state`
+container.
+
 #### Authentication Policy
 
 An authentication policy is a set of rules that defines which CA can be trusted
@@ -194,6 +199,7 @@ module: gnsi-certz
     +--ro certificate-revocation-list-bundle-created-on?   created-on
     +--ro authentication-policy-version?                   version
     +--ro authentication-policy-created-on?                created-on
+    +--ro ssl-profile-id?                                  string
     +--ro counters
        +--ro access-rejects?       oc-yang:counter64
        +--ro last-access-reject?   oc-types:timeticks64
@@ -640,6 +646,7 @@ module: openconfig-system
               +--ro gnsi-certz:certificate-revocation-list-bundle-created-on?   created-on
               +--ro gnsi-certz:authentication-policy-version?                   version
               +--ro gnsi-certz:authentication-policy-created-on?                created-on
+              +--ro gnsi-certz:ssl-profile-id?                                  string
               +--ro gnsi-certz:counters
                  +--ro gnsi-certz:access-rejects?       oc-yang:counter64
                  +--ro gnsi-certz:last-access-reject?   oc-types:timeticks64

--- a/certz/gnsi-certz.html
+++ b/certz/gnsi-certz.html
@@ -8455,6 +8455,24 @@ oc-types:timeticks64
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/gnsi-certz:authentication-policy-created-on</td>
         </tr>
         <tr id="1-1-16-42-65-94" class="a">
+
+            <td nowrap>
+                <div id=9999 class=tier6>
+                    <a class="leaf">&nbsp;</a>
+                    <attr title="The ID of this gRPC server's SSL profile
+as used by the gNSI Certz service"> <em> gnsi-certz:ssl-profile-id </em></abbr>
+                </div>
+         </td>
+         <td nowrap>leaf</td>
+         <td nowrap><abbr title="string
+">string</abbr></td>
+
+         <td nowrap>no config</td>
+         <td>?</td>
+         <td>current</td>
+         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/gnsi-certz:ssl-profile-id</td>
+     </tr>
+        <tr id="1-1-16-42-65-95" class="a">
         
             <td nowrap id="p4000">
                <div id="p5000" class="tier6">
@@ -8473,7 +8491,7 @@ the authentication process.">gnsi-certz:counters</abbr>
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/gnsi-certz:counters</td>
         </tr>
-        <tr id="1-1-16-42-65-94-138" class="a">
+        <tr id="1-1-16-42-65-95-138" class="a">
         
             <td nowrap>
                <div id=9999 class=tier7>
@@ -8492,7 +8510,7 @@ uint64
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/gnsi-certz:counters/gnsi-certz:access-rejects</td>
         </tr>
-        <tr id="1-1-16-42-65-94-139" class="a">
+        <tr id="1-1-16-42-65-95-139" class="a">
         
             <td nowrap>
                <div id=9999 class=tier7>
@@ -8512,7 +8530,7 @@ uint64
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/gnsi-certz:counters/gnsi-certz:last-access-reject</td>
         </tr>
-        <tr id="1-1-16-42-65-94-140" class="a">
+        <tr id="1-1-16-42-65-95-140" class="a">
         
             <td nowrap>
                <div id=9999 class=tier7>
@@ -8532,7 +8550,7 @@ uint64
         <td>current</td>
         <td nowrap>/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/oc-sys-grpc:state/gnsi-certz:counters/gnsi-certz:access-accepts</td>
         </tr>
-        <tr id="1-1-16-42-65-94-141" class="a">
+        <tr id="1-1-16-42-65-95-141" class="a">
         
             <td nowrap>
                <div id=9999 class=tier7>

--- a/certz/gnsi-certz.yang
+++ b/certz/gnsi-certz.yang
@@ -25,6 +25,12 @@ module gnsi-certz {
         "This module provides a data model for the metadata of gRPC credentials
         installed on a networking device.";
 
+    revision 2023-08-24 {
+        description
+            "Adds ssl-profile-id leaf";
+        reference "0.4.0";
+    }
+
     revision 2023-05-10 {
         description
             "Adds authentication policy freshness information.";
@@ -152,6 +158,12 @@ module gnsi-certz {
             description
                 "The timestamp of the moment when the authentication policy
                 that is currently used by this gRPC server was created.";
+        }
+        leaf ssl-profile-id {
+            type string;
+            description
+                "The ID of this gRPC server's SSL profile
+                as used by the gNSI Certz service";
         }
     }
 


### PR DESCRIPTION
This leaf creates an association between a particular gRPC server and the ID of the SSL profile that it is running with.
see https://github.com/openconfig/gnsi/issues/111