### PR TITLE
Provision for clearing SSH authorized keys/principals from configuration

### DIFF
--- a/credentialz/credentialz.proto
+++ b/credentialz/credentialz.proto
@@ -444,8 +444,10 @@ message AccountCredentials {
 
   // The system role account name (e.g. root). This account must exist.
   string account = 1;
-  // `authorized_keys` specifies one or more SSH keys that is permitted for the
+  // `authorized_keys` specifies zero or more SSH keys that is permitted for the
   // system role.
+  // If zero SSH keys are specified, currently configured SSH keys for the user
+  // will be cleared from configuration.
   repeated AuthorizedKey authorized_keys = 2;
   // `version` contains versioning information that is controlled by
   // the credential manager and reported as-is by the telemetry reporting system
@@ -481,8 +483,10 @@ message AuthorizedUsersRequest {
 
 message UserPolicy {
   message SshAuthorizedPrincipals {
-    // List of system users to authorized principal mapping for certificate
-    // authentication.
+    // List of zero or more system users to authorized principal mapping for
+    // certificate authentication.
+    // If no authorized principals are specified, currently configured authorized
+    // principals for the user will be cleared from configuration.
     repeated SshAuthorizedPrincipal authorized_principals = 2;
   }
   message SshAuthorizedPrincipal {

--- a/credentialz/credentialz.proto
+++ b/credentialz/credentialz.proto
@@ -485,8 +485,8 @@ message UserPolicy {
   message SshAuthorizedPrincipals {
     // List of zero or more system users to authorized principal mapping for
     // certificate authentication.
-    // If no authorized principals are specified, currently configured authorized
-    // principals for the user will be cleared from configuration.
+    // If no authorized principals are specified, currently configured
+    // authorized principals for the user will be cleared from configuration.
     repeated SshAuthorizedPrincipal authorized_principals = 2;
   }
   message SshAuthorizedPrincipal {

--- a/credentialz/credentialz.proto
+++ b/credentialz/credentialz.proto
@@ -444,8 +444,8 @@ message AccountCredentials {
 
   // The system role account name (e.g. root). This account must exist.
   string account = 1;
-  // `authorized_keys` specifies zero or more SSH keys that is permitted for the
-  // system role.
+  // `authorized_keys` specifies zero or more SSH keys that are permitted for
+  // the system role.
   // If zero SSH keys are specified, currently configured SSH keys for the user
   // will be cleared from configuration.
   repeated AuthorizedKey authorized_keys = 2;


### PR DESCRIPTION
Add comments to the proto file which specifies how to clear the configured authorized keys/principals from configuration.