### PR TITLE
README references the wrong yang filename

### DIFF
--- a/authz/README.md
+++ b/authz/README.md
@@ -320,7 +320,7 @@ expected result of the `gNSI.authz.Probe()` RPC is:
 
 ### `gnsi-authz.yang`
 
-An overview of the changes defined in the `gnmi-authz.yang` file are shown
+An overview of the changes defined in the `gnsi-authz.yang` file are shown
 below.
 
 ```txt


### PR DESCRIPTION
Simple import error from this module's origin.