### PR TITLE
gnsi/pathz: clarify rotation behaviour for ongoing gNMI subscriptions

### DIFF
--- a/pathz/index.md
+++ b/pathz/index.md
@@ -93,7 +93,8 @@ sent, the proposed configuration is rolled back automatically.
 
 ### AuthorizationPolicy rotation and gNMI subscriptions
 
-When the pathz policy is rotated, ongoing gNMI subscriptions will be dropped.   
+When the pathz policy is rotated, ongoing gNMI subscriptions will be dropped.
+
 This forces gNMI clients to reconnect and ensures that all gNMI subscriptions
 are proceeding using the most recent pathz policy.
 

--- a/pathz/index.md
+++ b/pathz/index.md
@@ -91,6 +91,12 @@ out the action.
 If the stream is disconnected prior to the Finalize message being
 sent, the proposed configuration is rolled back automatically.
 
+### AuthorizationPolicy rotation and gNMI subscriptions
+
+When the pathz policy is rotated, ongoing gNMI subscriptions will be dropped.   
+This forces gNMI clients to reconnect and ensures that all gNMI subscriptions
+are proceeding using the most recent pathz policy.
+
 ## Open Questions/Considerations
 
 None to date.


### PR DESCRIPTION
The index.md is updated with a section covering the expected behaviour for ongoing subscriptions when a server
experiences a pathz policy change.

This commit also updates the pathz.UploadResponse value so that
it contains information about ongoing subscriptions and whether
they would experience different behaviour under the incoming policy. .pb.go files were regenerated.