### PR TITLE
Fix typo in the YANG leaf name

### DIFF
--- a/credentialz/gnsi-credentialz.yang
+++ b/credentialz/gnsi-credentialz.yang
@@ -22,6 +22,12 @@ module gnsi-credentialz {
         "This module provides a data model for the metadata of SSH and console
          credentials installed on a networking device.";
 
+    revision 2024-01-05 {
+        description
+            "Fix typo in YANG leaves";
+        reference "0.5.0";
+    }  
+
     revision 2023-10-03 {
         description
             "Added state leaves for admin-user";
@@ -101,7 +107,7 @@ module gnsi-credentialz {
                 "The version of the host public key.";
         }
 
-        leaf active-host-key-version-created-on {
+        leaf active-host-key-created-on {
             type created-on;
             description
                 "The timestamp of the moment when the host key was


### PR DESCRIPTION
Incremented the revision due to the change in leaf names in [this](https://github.com/openconfig/gnsi/commit/241b10833884ad01fb04e08023b6d5507566e10a). This also fixes a typo in a leaf name.