### PR TITLE
Update docs & comments for the behavior of the RecordSubscribe service,

### DIFF
--- a/acctz/README.md
+++ b/acctz/README.md
@@ -12,7 +12,7 @@ Accounting Records are available at a gNSI origin:
    gnsi.acctz
 
 Records may be streamed from a system at request of the remote collector,
-via the AccountingPull() service/rpc.
+via the RecordSubscribe() service/rpc.
 
 Configuration of the Accounting service is made through standard
 gNxI methods using the defined YANG model.
@@ -26,9 +26,8 @@ time at which the accounted event occured, local to the system which sends
 the message. This could be different from the time received at the Collector
 and the time the Record was emitted from the system.
 
-The stream method requires that acknowledgements be sent periodically
-in order to signal both which messages have been successfully processed
-and that the remote collector is alive.
+The stream continues as new records are received by the accounting subsystem,
+ending when the gNSI session ends or an error occurs.
 
 Devices should maintain a history of accounting records so that they can be
 retrieved periodically by newly and already connected Collectors.  The depth

--- a/acctz/acctz.proto
+++ b/acctz/acctz.proto
@@ -66,10 +66,13 @@ service Acctz {
   // System should be sent to the Collector. A current time indicates that only
   // new messages should be sent.
   //
-  // The Collector must send a RecordRequest at least every 60 seconds, in
-  // order to signal its liveliness to the system. Failure to send a
-  // RecordRequest for more than 120 seconds will cause the connection to be
-  // reset.
+  // The stream continues ad infinitum, until the gNSI session is severed.
+  // The gNSI TCP connection could timeout due to expiration of the TCP
+  // keepalive mechanism, or the server could disconnect the client if the
+  // output buffer to the client remains full for a long timeout period,
+  // implying a stuck client (see also getsockopt(SIOCOUTQ) and
+  // https://datatracker.ietf.org/doc/draft-ietf-idr-bgp-sendholdtimer/).
+  //
   rpc RecordSubscribe(stream RecordRequest) returns (stream RecordResponse);
 }
 


### PR DESCRIPTION
removing the keepalive concept and mentioning the behavior the server can adopt to timeout a dead client.

Addresses issue #137 