### PR TITLE
gnsi/certz: fix error in yang description

### DIFF
--- a/certz/gnsi-certz.html
+++ b/certz/gnsi-certz.html
@@ -8496,7 +8496,7 @@ the authentication process.">gnsi-certz:counters</abbr>
             <td nowrap>
                <div id=9999 class=tier7>
                   <a class="leaf">&nbsp;</a>
-                  <attr title="The total number of times that gRPC clients have succeeded
+                  <attr title="The total number of times that gRPC clients have failed
 in establishing a connection to the server."> <em> gnsi-certz:connection-rejects </em></abbr>
 
                </div>

--- a/certz/gnsi-certz.yang
+++ b/certz/gnsi-certz.yang
@@ -87,14 +87,14 @@ module gnsi-certz {
             leaf connection-rejects {
                 type oc-yang:counter64;
                 description
-               "The total number of times that gRPC clients have succeeded
+               "The total number of times that gRPC clients have failed
                in establishing a connection to the server.";
             }
             leaf last-connection-reject {
                 type oc-types:timeticks64;
                 description
                 "A timestamp of the last time a gRPC client failed
-                in establishing a connection to the server."
+                in establishing a connection to the server.";
             }
             leaf connection-accepts {
                 type oc-yang:counter64;
@@ -106,7 +106,7 @@ module gnsi-certz {
                 type oc-types:timeticks64;
                 description
                 "A timestamp of the last time a gRPC client succeeded
-                in establishing a connection to the server."
+                in establishing a connection to the server.";
             }
         }
     }


### PR DESCRIPTION
`connection-rejects` should increment for failed
connection attempts

YANG descriptions should have semicolons at the end