### PR TITLE
Update readme to use agreed upon profile name and clarify the

### DIFF
--- a/certz/README.md
+++ b/certz/README.md
@@ -40,10 +40,9 @@ Certificate Authority chain of certificates (a.k.a. a CA trust bundle) and
 a set of Certificate Revocation Lists into a set that then can be assigned
 as a whole to a gRPC server.
 
-There is at least one profile present on a target - the one that is used by
-the gNxI server. Its ID is `gNxI` but when the `ssl_profile_id` field in the
+There is always at least one profile present on a target - the `system_default_profile` which is vendor provided. This profile cannot be changed. If the use but when the `ssl_profile_id` field in the
 `RotateCertificateRequest` message is not set (or set to an empty string) it
-also refers this SSL profile.
+also refers this SSL profile. (This statement will be deprecated once all vendors standardize on the key name)
 
 Profiles existing on a target can be discovered using the
 `Certz.GetProfileList()` RPC.
@@ -97,9 +96,11 @@ policy before accepting the connection.
 
 The system will always provide a default TLS profile that uses the IDevID cert.
 This profile will always be available and cannot be changed. It should use the name
-"gNxI".
+"system_default_profile".
 
 An attempt to change or delete this profile will return an error.
+
+The system will start with this profile and either bootz or enrollz will be responsible for creating an alternate profile during device turnup if those workflows are used.
 
 #### Create a SSL profile
 

--- a/certz/certz.proto
+++ b/certz/certz.proto
@@ -41,7 +41,8 @@ option go_package = "github.com/openconfig/gnsi/cert";
 //
 // Target (as seen from gNSI.certificate microservice point of view)
 // |
-// +-+ SSL profile for gNXI; always present; ssl_profile_id := "gNxI"
+// +-+ SSL profile for gNXI; always present and immutable; 
+//   | ssl_profile_id := "system_default_profile"
 // | |
 // | +-+ certificate
 // | | +- certificate (with public key)


### PR DESCRIPTION
expectation that only new profiles will be created to use other certs