### PR TITLE
certz: clarify usage of entity_type field

### DIFF
--- a/certz/README.md
+++ b/certz/README.md
@@ -106,8 +106,8 @@ The system will start with this profile and either bootz or enrollz will be resp
 
 Call `Certz.AddProfile` RPC with the `ssl_profile_id` field specifying the ID
 of the new SSL profile.
-A new profile can choose to use existing artifacts from other profiles, via sending `Entity` messages with `ExistingEntity` set with the ssl_profile_id set to the source
-profile to copy from.
+A new profile can choose to use existing artifacts from other profiles, via sending `Entity` messages with `ExistingEntity` set with the `ssl_profile_id` set to the source
+profile to copy from, and the `entity_type` field set to the type of entity to be copied.
 
 #### Delete a SSL profile
 

--- a/certz/certz.proto
+++ b/certz/certz.proto
@@ -523,7 +523,11 @@ message Entity {
 // ExistingEntity is used to use artifacts provided by another SSL policy.
 // This operation will copy the entity from the provided policy and entity
 // type into the policy defined in the Rotate Request.
-// If the ssl profile doesn't exist an error will be returned.
+// If the ssl profile doesn't exist a NotFound error will be returned.
+// If the entity type to copy is already being provided in the same
+// UploadRequest then an InvalidArgument error will be returned.
+// (e.g. EntityType == ENTITY_TYPE_TRUST_BUNDLE cannot be used
+// if the UploadRequest contains a trust_bundle entity already)
 message ExistingEntity {
   enum EntityType {
     ENTITY_TYPE_UNSPECIFIED = 0;


### PR DESCRIPTION
clarify that we should return an error if the
entity_type field matches the type of an entity already
 being rotated in the same UploadRequest.
 
I.e. the artifact being rotated should either be uploaded in
the UploadRequest _or_ it should be copied from an
existing ssl profile, but not both.