### PR TITLE
Default go build rule in pathz

### DIFF
--- a/pathz/BUILD.bazel
+++ b/pathz/BUILD.bazel
@@ -56,3 +56,9 @@ go_proto_library(
         "@com_github_openconfig_gnmi//proto/gnmi:gnmi_go_proto",
     ],
 )
+
+go_library(
+    name = "pathz",
+    embed = [":pathz_go_proto"],
+    importpath = "github.com/openconfig/gnsi/pathz",
+)


### PR DESCRIPTION
Adds a default build rule for pathz to mirror the behavior of other protos