### PR TITLE
Update BUILD.bazel

### DIFF
--- a/version/BUILD.bazel
+++ b/version/BUILD.bazel
@@ -31,7 +31,7 @@ go_proto_library(
     importpath = "github.com/openconfig/gnsi/version",
     proto = ":version_proto",
     deps = [
-        "@com_github_openconfig_gnoi//types:types_go_proto",
+        "@com_github_openconfig_gnoi//types",
     ],
 )
 


### PR DESCRIPTION
link: package conflict error: github.com/openconfig/gnsi/version: package imports github.com/openconfig/gnoi/types
          was compiled with: @com_github_openconfig_gnoi//types:types_go_proto
        but was linked with: @com_github_openconfig_gnoi//types:types