### PR TITLE
certz: clarify comment for TrustBundle.pkcs7_block field

### DIFF
--- a/certz/certz.proto
+++ b/certz/certz.proto
@@ -443,8 +443,8 @@ message CertificateChain {
 }
 
 message TrustBundle {
-  // A trust_bundle may be a PKCS#7 encoded string.
-  // This is a single string with many PEM encoded public keys included.
+  // A pkcs7_block will be a PKCS#7 encoded string.
+  // This is a single string with many PEM encoded certificates included.
   string pkcs7_block = 1;
 }
 


### PR DESCRIPTION
This will be a bundle of certificates, not public keys