### PR TITLE
certz: clarify that ssl_profile_id cannot be empty

### DIFF
--- a/certz/README.md
+++ b/certz/README.md
@@ -40,9 +40,9 @@ Certificate Authority chain of certificates (a.k.a. a CA trust bundle) and
 a set of Certificate Revocation Lists into a set that then can be assigned
 as a whole to a gRPC server.
 
-There is always at least one profile present on a target - the `system_default_profile` which is vendor provided. This profile cannot be changed. If the use but when the `ssl_profile_id` field in the
-`RotateCertificateRequest` message is not set (or set to an empty string) it
-also refers this SSL profile. (This statement will be deprecated once all vendors standardize on the key name)
+There is always at least one profile present on a target - the `system_default_profile` which is vendor provided.
+This profile cannot be changed or deleted.
+See the the [System default SSL profile](#system-default-ssl-profile) section below.
 
 Profiles existing on a target can be discovered using the
 `Certz.GetProfileList()` RPC.

--- a/certz/certz.proto
+++ b/certz/certz.proto
@@ -286,8 +286,8 @@ message RotateCertificateRequest {
 
   // An identifier for the specific SSL profile (collection of
   // certs/bundles/CRLs) which is being rotated through this stream.
-  // Leaving this field blank means that this stream will rotate the SSL profile
-  // which is currently being used by the gNSI service.
+  // Leaving this field blank will result in an InvalidArgument error
+  // being returned to the client
   string ssl_profile_id = 2;
 
   // Request Messages.
@@ -586,6 +586,9 @@ message ExistingEntity {
     ENTITY_TYPE_AUTHENTICATION_POLICY = 4;
   }
 
+  // The existing SSL profile to reference.
+  // Leaving this field blank will result in an InvalidArgument error
+  // being returned to the client
   string ssl_profile_id = 1;
   EntityType entity_type = 2;
 }


### PR DESCRIPTION
The ssl_profile_id field should always be set,
and providing an empty ssl_profile_id to the server should result in an error being returned.