### PR TITLE
Add credentialz endpoints to manage system role accounts.

### DIFF
--- a/credentialz/credentialz.proto
+++ b/credentialz/credentialz.proto
@@ -224,6 +224,16 @@ service Credentialz {
   // Get the current public keys from the host. Each configured key will be
   // returned in the provided list.
   rpc GetPublicKeys(GetPublicKeysRequest) returns (GetPublicKeysResponse);
+
+  // Add a system role account.
+  // Note that an attempt to add a system role account that already exists will
+  // be rejected with an error.
+  rpc AddAccount(AddAccountRequest) returns (AddAccountResponse);
+
+  // Delete a system role account.
+  // Note that an attempt to delete a system role account that doesn't exist
+  // will be rejected with an error.
+  rpc DeleteAccount(DeleteAccountRequest) returns (DeleteAccountResponse);
 }
 
 //
@@ -787,3 +797,17 @@ message GetPublicKeysResponse {
   // Return all currently configured keys on host.
   repeated PublicKey public_keys = 1;
 }
+
+message AddAccountRequest {
+  // The system role account name. This account must not already exist.
+  string account = 1;
+}
+
+message AddAccountResponse {}
+
+message DeleteAccountRequest {
+  // The system role account name. This account must exist.
+  string account = 1;
+}
+
+message DeleteAccountResponse {}


### PR DESCRIPTION
It seems there is no way to manage system role accounts via openconfig today, meaning it's necessary to know about the NOS or underlying OS in order to get that done.