### PR TITLE
Add TPM2B_CREATION_DATA to the MBM data.

### DIFF
--- a/certz/README.md
+++ b/certz/README.md
@@ -203,6 +203,8 @@ Send a `Certz.GenerateCSRRequest` to the `Certz.Rotate` endpoint, containing a
 and the `MBMData` within, do the following:
 
 * Verify the `ek_leaf_cert` using the `ek_cert_chain` and your trust anchor.
+* Optional: Verify that the AK matches your expectations, using the
+  `ak_creation_data` struct.
 * Validate the `ak_signature` over the `ak_attestation` struct which was
   certified by the EK, and validate its contents. This verifies the AK.
 * Validate the `signature` over `quoted` by the AK. Then validate that the PCRs

--- a/certz/certz.proto
+++ b/certz/certz.proto
@@ -739,6 +739,13 @@ message MBMData {
   // The AK public key in PEM format.
   string ak_pub_key = 5;
 
+  // The AK attestation key creation data `TPM2B_CREATION_DATA` structure. See
+  // section 24.1 of
+  // https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf#page=293 protolint:disable:this MAX_LINE_LENGTH
+  // and section 15.2 of
+  // https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part2_Structures_pub.pdf#page=176. protolint:disable:this MAX_LINE_LENGTH
+  bytes ak_creation_data = 9;
+
   // The AK attestation `TPM2B_ATTEST` structure. See section 18.3 of
   // https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf#page=163 protolint:disable:this MAX_LINE_LENGTH
   // and section 10.12.13 of


### PR DESCRIPTION
This structure is created by TPM2_CreatePrimary(), and provides information relating to the creation environment for the AK, such as the parent name. Exposing this allows verifiers to check that appropriate values were set.