### PR TITLE
Pin GitHub Actions to specific commits

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,18 +15,18 @@ jobs:
     env:
       BAZEL: bazelisk-linux-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
       - name: Mount bazel cache
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: "~/.cache/bazel"
           key: bazel-${{ runner.os }}-build-${{ hashFiles('**/*.bzl', '**/*.bazel') }}
           restore-keys: |
             bazel-${{ runner.os }}-build-
       - name: Setup Bazel
-        uses: bazelbuild/setup-bazelisk@v2
+        uses: bazelbuild/setup-bazelisk@b39c379c82683a5f25d34f0d062761f62693e0b2 # v3
       - name: Build
         run: bazel build //...
       - name: Test

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -12,8 +12,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      BAZEL: bazelisk-linux-amd64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -25,8 +25,6 @@ jobs:
           key: bazel-${{ runner.os }}-build-${{ hashFiles('**/*.bzl', '**/*.bazel') }}
           restore-keys: |
             bazel-${{ runner.os }}-build-
-      - name: Setup Bazel
-        uses: bazelbuild/setup-bazelisk@b39c379c82683a5f25d34f0d062761f62693e0b2 # v3
       - name: Build
         run: bazel build //...
       - name: Test

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,11 +28,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
       - name: Lint Code Base
-        uses: github/super-linter/slim@v5
+        uses: github/super-linter/slim@a8150b40c89574adb5f68bf9502b890a236a06b3 # v5
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_HTML: false


### PR DESCRIPTION
Pin Github Actions to [specific commit hashes](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) instead of tags.

setup-bazelisk action is removed because it is not needed; bazelisk is included in the base runner image.