### PR TITLE
certz: clarify usage of CERT_SOURCE_IDEVID

### DIFF
--- a/certz/certz.proto
+++ b/certz/certz.proto
@@ -487,6 +487,14 @@ message Certificate {
 
     // certificates present on the device already
     CERT_SOURCE_OIDEVID = 1;
+
+    // CERT_SOURCE_IDEVID can only be used on the leaf Certificate in a
+    // CertificateChain, and that if the leaf Certificate has cert_source
+    // set to CERT_SOURCE_IDEVID, then no Parent CertificateChain
+    // should be set.
+    // Internally, the handling for CERT_SOURCE_IDEVID may involve the device
+    // configuring one or more certificates in the ssl profile, so that it
+    // forms a valid and usable certificate chain.
     CERT_SOURCE_IDEVID = 2;
     // self-signed certificate generated on device
     CERT_SOURCE_SELFSIGNED = 3;


### PR DESCRIPTION
comment how CERT_SOURCE_IDEVID usage should be
handled, both from the client side (clients should
only set it in their  leaf certificate, and should
not add any explicit intermediate certs), and from
the server side (servers should expand this enum
to represent one or more certificates until a usable
certificate chain can be formed).

This gives the client a defined workflow to keep it
vendor-neutral, but means that if the device would
require an intermediate cert to make the ssl profile usable,
then the server has the freedom to add it.