### PR TITLE
certz: clarify that Rotate RPCs not be interrupted by TLS->mTLS transitions

### DIFF
--- a/certz/certz.proto
+++ b/certz/certz.proto
@@ -251,6 +251,12 @@ service Certz {
   // by requesting a CSR for profile B using the same `Rotate` RPC). In the
   // case that such multiplexing is observed, the server should respond with
   // an error specifying `InvalidArgument` as the status code.
+  //
+  // A `Rotate` RPC should not cause an SSL profile to transition from
+  // TLS to mTLS, if that SSL profile is in-use by the gRPC server which
+  // is currently hosting the Certz service through which the Rotate RPC
+  // is being performed. Attempting to do this should cause the server
+  // to respond with an error specifying `InvalidArgument` as the status code.
   rpc Rotate(stream RotateCertificateRequest)
       returns (stream RotateCertificateResponse);
 


### PR DESCRIPTION
If a server is moved from TLS -> mTLS (i.e. by rotation of a trust_bundle to a particular SSL profile which did not previously have a trust_bundle assigned), then the server may require a reload to apply these changes.
Such a reload would interrupt the Certz Rotate RPC if it was ongoing via that server.
Clarify here that servers should explicitly not allow this to occur.